### PR TITLE
Add screening progress

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -54,8 +54,7 @@ export const migrate = async () => {
         "identify-mock691f4e49fc43b913bd8ede668e187e9a-1509032370615": {
           id: "identify-mock691f4e49fc43b913bd8ede668e187e9a-1509032370615",
           reference: null,
-          url:
-            "https://go.test.idnow.de/kontist/identifications/identify-mock691f4e49fc43b913bd8ede668e187e9a-1509032370615",
+          url: "https://go.test.idnow.de/kontist/identifications/identify-mock691f4e49fc43b913bd8ede668e187e9a-1509032370615",
           status: "successful",
           completed_at: null,
           method: "idnow",
@@ -74,6 +73,7 @@ export const migrate = async () => {
           method: "idnow",
         },
       },
+      screening_progress: null,
       transactions: [
         {
           id: "e0492abb-87fd-42a2-9303-708026b90c8e",
@@ -469,7 +469,7 @@ export const getPersonByFraudCaseId = async (fraudCaseId) => {
 
 export const getCard = async (cardId) => (await getCardData(cardId)).card;
 
-export const getPersonByDeviceId = async deviceId => {
+export const getPersonByDeviceId = async (deviceId) => {
   const device = await getDevice(deviceId);
   return getPerson(device.person_id);
 };

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -388,6 +388,13 @@ export enum IdentificationStatus {
   CANCELED = "canceled",
 }
 
+export enum ScreeningStatus {
+  NOT_SCREENED = "NOT_SCREENED",
+  POTENTIAL_MATCH = "POTENTIAL_MATCH",
+  SCREENED_ACCEPTED = "SCREENED_ACCEPTED",
+  SCREENED_DECLINED = "SCREENED_DECLINED",
+}
+
 export enum OverdraftApplicationStatus {
   CREATED = "created",
   INITIAL_SCORING_PENDING = "initial_scoring_pending",

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -34,6 +34,7 @@ import {
   AccountWebhookEvent,
   TransactionWebhookEvent,
   IdentificationStatus,
+  ScreeningStatus,
 } from "../helpers/types";
 import {
   changeOverdraftApplicationStatus,
@@ -229,6 +230,13 @@ export const setIdentificationState = async (req, res) => {
   const person = await getPerson(identification.person_id);
   identification.status = status;
   person.identifications[identification.id] = identification;
+
+  if (
+    identification.status === IdentificationStatus.SUCCESSFUL ||
+    identification.status === IdentificationStatus.PENDING_SUCCESSFUL
+  ) {
+    person.screening_progress = ScreeningStatus.SCREENED_ACCEPTED;
+  }
 
   await savePerson(person);
 

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -232,8 +232,10 @@ export const setIdentificationState = async (req, res) => {
   person.identifications[identification.id] = identification;
 
   if (
-    identification.status === IdentificationStatus.SUCCESSFUL ||
-    identification.status === IdentificationStatus.PENDING_SUCCESSFUL
+    [
+      IdentificationStatus.SUCCESSFUL,
+      IdentificationStatus.PENDING_SUCCESSFUL,
+    ].includes(identification.status)
   ) {
     person.screening_progress = ScreeningStatus.SCREENED_ACCEPTED;
   }


### PR DESCRIPTION
Addresses ticket [#6607](https://github.com/kontist/app/issues/6607)

Extends the `person` with `screening_progress : null`. 
When the identification status is updated to `successful` or `pending_successful` then automatically update the `screening_progress` status to `screened_accepted` so that we're not blocked on the pending screen when testing. 

Doc : 
- When we create a new person, the screening_progress should be send back in the response : https://docs.solarisbank.com/core/api/v1/#44qZGy7K-post-create-a-person
- The screening status is an additional check just after the idnow check, the goal is to be sure that this person is not black listed somewhere. Only once identification is successful / pending-successful AND screening status is screened_accepted then we can trigger the account opening : https://docs.solarisbank.com/core/guides/#44IpmP29-account-opening