### PR TITLE
dont throw if no account

### DIFF
--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -421,8 +421,8 @@ export const generateBookingForPerson = (bookingData) => {
   } = bookingData;
 
   const recipientName = `${person.salutation} ${person.first_name} ${person.last_name}`;
-  const recipientIBAN = person.account.iban;
-  const recipientBIC = person.account.bic;
+  const recipientIBAN = person.account?.iban;
+  const recipientBIC = person.account?.bic;
 
   const senderIBAN = iban || "ES3183888553310516236778";
   const senderBIC = process.env.SOLARIS_BIC;


### PR DESCRIPTION
 https://github.com/kontist/backend/issues/9700#issuecomment-953746934

So we have an error in ~10% of the time when webapp calls
e2e/users/{email}/bank-transactions

When BE receive this call it sends a request to mocksolaris. And this request to mocksolaris sometimes fails because person.account is undefined:
https://github.com/kontist/mock-solaris/blob/71d5a40d6648c82938b16bf38cfa43c9a53ae93c/src/routes/backoffice.ts#L424