### PR TITLE
Set screening status manually and from an endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This mock service currently supports (at different extents)
 - Seizures
 - Direct Debit Returns
 - Webhooks
+- Customer Due Diligence
 - ...
 
 ### TAN
@@ -51,6 +52,14 @@ For device binding, you can use any combination as the 6-digit TAN (it is not ac
 
 For other TAN confirmation (Change Requests, Transfer confirmation, etc.), you can find the 6-digit code on your user's UI:
 ![TAN](https://github.com/kontist/mock-solaris/blob/assets/tan.png)
+
+### Onboarding a person - Customer due diligence (CDD)
+
+A successfully onboarded person must have "green" values for screening values. 
+You can set screenng values from the "Person data" section ([More info](https://docs.solarisbank.com/guides/get-started/digital-banking/onboard-person/#customer-due-diligence-cdd))
+
+<img width="532" alt="Screen Shot 2022-07-18 at 11 38 55 AM" src="https://user-images.githubusercontent.com/6367201/179475427-58af2c02-b229-4cab-96a2-089f45356e60.png">
+
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ curl TODO
 
 ## Backoffice screenshots
 
-![User setup](https://github.com/kontist/mock-solaris/blob/assets/individual-user.png)
+![mockSolarisPerson](https://user-images.githubusercontent.com/6367201/179481833-0d7087cc-1682-435d-94f5-ed316140eaa2.png)
+
 
 ### Persons and accounts
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For other TAN confirmation (Change Requests, Transfer confirmation, etc.), you c
 ### Onboarding a person - Customer due diligence (CDD)
 
 A successfully onboarded person must have "green" values for screening values. 
-You can set screenng values from the "Person data" section ([More info](https://docs.solarisbank.com/guides/get-started/digital-banking/onboard-person/#customer-due-diligence-cdd))
+You can set screening values from the "Person data" section ([More info](https://docs.solarisbank.com/guides/get-started/digital-banking/onboard-person/#customer-due-diligence-cdd))
 
 <img width="532" alt="Screen Shot 2022-07-18 at 11 38 55 AM" src="https://user-images.githubusercontent.com/6367201/179475427-58af2c02-b229-4cab-96a2-089f45356e60.png">
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.44-experimental",
+  "version": "1.0.45-experimental",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.46-experimental",
+  "version": "1.0.47",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.45-experimental",
+  "version": "1.0.46-experimental",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.43-experimental",
+  "version": "1.0.44-experimental",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.42-experimental",
+  "version": "1.0.43-experimental",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.41-experimental",
+  "version": "1.0.42-experimental",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.39",
+  "version": "1.0.41-experimental",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -529,6 +529,11 @@ app.post(
   safeRequestHandler(backofficeAPI.setIdentification)
 );
 
+app.post(
+  "/__BACKOFFICE__/setScreening/:id",
+  safeRequestHandler(backofficeAPI.setScreening)
+);
+
 app.get(
   "/__BACKOFFICE__/person/:id",
   safeRequestHandler(backofficeAPI.getPersonHandler)

--- a/src/app.ts
+++ b/src/app.ts
@@ -530,7 +530,7 @@ app.post(
 );
 
 app.post(
-  "/__BACKOFFICE__/setScreening/:id",
+  "/__BACKOFFICE__/setScreening/:email",
   safeRequestHandler(backofficeAPI.setScreening)
 );
 

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -195,7 +195,8 @@ const shouldMarkMobileNumberAsVerified = (identification) =>
   ].includes(identification.status) && identification.method === "idnow";
 
 export const setIdentification = async (req, res) => {
-  const { identification, skipSettingScreeningValues } = req.body;
+  const identification = req.body;
+  const { skipSettingScreeningValues } = req.body;
   const personSolarisId = req.params.id;
   const person = await getPerson(personSolarisId);
   person.identifications[identification.id] = identification;

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -235,6 +235,7 @@ export const setIdentification = async (req, res) => {
   res.status(204).send();
 };
 
+// sets identification state from the panel
 export const setIdentificationState = async (req, res) => {
   const { status } = req.body;
 
@@ -255,19 +256,6 @@ export const setIdentificationState = async (req, res) => {
   const person = await getPerson(identification.person_id);
   identification.status = status;
   person.identifications[identification.id] = identification;
-
-  // screening will not always be accepted.
-  if (
-    [
-      IdentificationStatus.SUCCESSFUL,
-      IdentificationStatus.PENDING_SUCCESSFUL
-    ].includes(identification.status)
-  ) {
-    // TODO: assign these values manually from the backend tests and remove this
-    person.screening_progress = ScreeningProgress.SCREENED_ACCEPTED;
-    person.risk_classification_status = RiskClarificationStatus.RISK_ACCEPTED;
-    person.customer_vetting_status = CustomerVettingStatus.RISK_ACCEPTED;
-  }
 
   await savePerson(person);
 

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -236,6 +236,10 @@ export const setIdentification = async (req, res) => {
   res.status(204).send();
 };
 
+/*
+ * Set customer screening values which are set by solarisbank
+ * @see @link {https://docs.solarisbank.com/guides/get-started/digital-banking/onboard-person/#customer-due-diligence-cdd}
+ */
 export const setScreening = async (req, res) => {
   const {
     screening_progress,

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -235,7 +235,6 @@ export const setIdentification = async (req, res) => {
   res.status(204).send();
 };
 
-// sets identification state from the panel
 export const setIdentificationState = async (req, res) => {
   const { status } = req.body;
 
@@ -256,6 +255,19 @@ export const setIdentificationState = async (req, res) => {
   const person = await getPerson(identification.person_id);
   identification.status = status;
   person.identifications[identification.id] = identification;
+
+  // screening will not always be accepted.
+  if (
+    [
+      IdentificationStatus.SUCCESSFUL,
+      IdentificationStatus.PENDING_SUCCESSFUL
+    ].includes(identification.status)
+  ) {
+    // TODO: assign these values manually from the backend tests and remove this
+    person.screening_progress = ScreeningProgress.SCREENED_ACCEPTED;
+    person.risk_classification_status = RiskClarificationStatus.RISK_ACCEPTED;
+    person.customer_vetting_status = CustomerVettingStatus.RISK_ACCEPTED;
+  }
 
   await savePerson(person);
 

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -243,16 +243,25 @@ export const setScreening = async (req, res) => {
     customer_vetting_status,
   } = req.body;
 
+  log.info(`setScreening req:`, req);
+
   const person = (await getAllPersons()).find(
     (item) => item.email === req.params.email
   );
+
+  log.info(
+    `getAllPersons last person: `,
+    (await getAllPersons()).length ? (await getAllPersons()).pop() : null
+  );
+  log.info(`setScreening person:`, person);
 
   person.screening_progress = screening_progress;
   person.risk_classification_status = risk_classification_status;
   person.customer_vetting_status = customer_vetting_status;
 
+  log.info(`setScreening person after updated values:`, person);
   await savePerson(person);
-
+  log.info(`setScreening person after saving object to db:`, person);
   await triggerWebhook(
     PersonWebhookEvent.PERSON_CHANGED,
     {},

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -244,7 +244,7 @@ export const setScreening = async (req, res) => {
   } = req.body;
 
   const person = (await getAllPersons()).find(
-    (person) => person.email === req.params.email
+    (item) => item.email === req.params.email
   );
 
   person.screening_progress = screening_progress;

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -256,7 +256,7 @@ export const setScreening = async (req, res) => {
   await triggerWebhook(
     PersonWebhookEvent.PERSON_CHANGED,
     {},
-    { "solaris-entity-id": req.params.id }
+    { "solaris-entity-id": person.id }
   );
   res.status(204).send();
 };

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -242,9 +242,10 @@ export const setScreening = async (req, res) => {
     risk_classification_status,
     customer_vetting_status,
   } = req.body;
-  const personSolarisId = req.params.id;
 
-  const person = await getPerson(personSolarisId);
+  const person = (await getAllPersons()).find(
+    (person) => person.email === req.params.email
+  );
 
   person.screening_progress = screening_progress;
   person.risk_classification_status = risk_classification_status;

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -195,13 +195,13 @@ const shouldMarkMobileNumberAsVerified = (identification) =>
   ].includes(identification.status) && identification.method === "idnow";
 
 export const setIdentification = async (req, res) => {
-  const identification = req.body;
+  const { identification, skipSettingScreeningValues } = req.body;
   const personSolarisId = req.params.id;
   const person = await getPerson(personSolarisId);
   person.identifications[identification.id] = identification;
 
   // TODO: assign these values manually from the backend tests and remove this
-  if (
+  if (!(skipSettingScreeningValues === "true") &&
     [
       IdentificationStatus.SUCCESSFUL,
       IdentificationStatus.PENDING_SUCCESSFUL
@@ -236,7 +236,7 @@ export const setIdentification = async (req, res) => {
 };
 
 export const setIdentificationState = async (req, res) => {
-  const { status } = req.body;
+  const { status, skipSettingScreeningValues } = req.body;
 
   log.info("setIdentificationState body", req.body);
   log.info("setIdentificationState params", req.params);
@@ -257,7 +257,7 @@ export const setIdentificationState = async (req, res) => {
   person.identifications[identification.id] = identification;
 
   // screening will not always be accepted.
-  if (
+  if (!(skipSettingScreeningValues === "true") &&
     [
       IdentificationStatus.SUCCESSFUL,
       IdentificationStatus.PENDING_SUCCESSFUL

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -13,11 +13,11 @@ import {
   deleteMobileNumber,
   saveSepaDirectDebitReturn,
   getDevicesByPersonId,
-  saveTaxIdentifications
+  saveTaxIdentifications,
 } from "../db";
 import {
   createSepaDirectDebitReturn,
-  triggerSepaDirectDebitReturnWebhook
+  triggerSepaDirectDebitReturnWebhook,
 } from "../helpers/sepaDirectDebitReturn";
 import { shouldReturnJSON } from "../helpers";
 import { triggerWebhook } from "../helpers/webhooks";
@@ -37,11 +37,11 @@ import {
   IdentificationStatus,
   ScreeningProgress,
   RiskClarificationStatus,
-  CustomerVettingStatus
+  CustomerVettingStatus,
 } from "../helpers/types";
 import {
   changeOverdraftApplicationStatus,
-  issueInterestAccruedBooking
+  issueInterestAccruedBooking,
 } from "../helpers/overdraft";
 
 const triggerIdentificationWebhook = (payload) =>
@@ -56,7 +56,7 @@ const triggerAccountBlockWebhook = async (person) => {
     business_id: null,
     locking_status: lockingStatus,
     updated_at: new Date().toISOString(),
-    iban
+    iban,
   };
 
   await triggerWebhook(AccountWebhookEvent.ACCOUNT_BLOCK, payload);
@@ -126,7 +126,7 @@ export const getPersonHandler = async (req, res) => {
   if (!person) {
     return res.status(HttpStatusCodes.NOT_FOUND).send({
       message: "Couldn't find person",
-      details: req.params
+      details: req.params,
     });
   }
 
@@ -143,7 +143,7 @@ export const getPersonHandler = async (req, res) => {
       taxIdentifications,
       devices,
       identifications: person.identifications,
-      SEIZURE_STATUSES
+      SEIZURE_STATUSES,
     });
   }
 };
@@ -191,7 +191,7 @@ export const updatePersonHandler = async (req, res) => {
 const shouldMarkMobileNumberAsVerified = (identification) =>
   [
     IdentificationStatus.PENDING_SUCCESSFUL,
-    IdentificationStatus.SUCCESSFUL
+    IdentificationStatus.SUCCESSFUL,
   ].includes(identification.status) && identification.method === "idnow";
 
 export const setIdentification = async (req, res) => {
@@ -201,10 +201,11 @@ export const setIdentification = async (req, res) => {
   person.identifications[identification.id] = identification;
 
   // TODO: assign these values manually from the backend tests and remove this
-  if (!(skipSettingScreeningValues === "true") &&
+  if (
+    !(skipSettingScreeningValues === "true") &&
     [
       IdentificationStatus.SUCCESSFUL,
-      IdentificationStatus.PENDING_SUCCESSFUL
+      IdentificationStatus.PENDING_SUCCESSFUL,
     ].includes(identification.status)
   ) {
     person.screening_progress = ScreeningProgress.SCREENED_ACCEPTED;
@@ -229,9 +230,33 @@ export const setIdentification = async (req, res) => {
     completed_at: identification.completed_at,
     reference: identification.reference,
     status: identification.status,
-    method: "idnow"
+    method: "idnow",
   });
 
+  res.status(204).send();
+};
+
+export const setScreening = async (req, res) => {
+  const {
+    screening_progress,
+    risk_classification_status,
+    customer_vetting_status,
+  } = req.body;
+  const personSolarisId = req.params.id;
+
+  const person = await getPerson(personSolarisId);
+
+  person.screening_progress = screening_progress;
+  person.risk_classification_status = risk_classification_status;
+  person.customer_vetting_status = customer_vetting_status;
+
+  await savePerson(person);
+
+  await triggerWebhook(
+    PersonWebhookEvent.PERSON_CHANGED,
+    {},
+    { "solaris-entity-id": req.params.id }
+  );
   res.status(204).send();
 };
 
@@ -257,10 +282,11 @@ export const setIdentificationState = async (req, res) => {
   person.identifications[identification.id] = identification;
 
   // screening will not always be accepted.
-  if (!(skipSettingScreeningValues === "true") &&
+  if (
+    !(skipSettingScreeningValues === "true") &&
     [
       IdentificationStatus.SUCCESSFUL,
-      IdentificationStatus.PENDING_SUCCESSFUL
+      IdentificationStatus.PENDING_SUCCESSFUL,
     ].includes(identification.status)
   ) {
     // TODO: assign these values manually from the backend tests and remove this
@@ -286,7 +312,7 @@ export const setIdentificationState = async (req, res) => {
     completed_at: identification.completed_at,
     reference: identification.reference,
     method,
-    status
+    status,
   });
 
   res.redirect(`/__BACKOFFICE__/person/${person.id}#identifications`);
@@ -313,8 +339,8 @@ const generateBookingFromStandingOrder = (standingOrder) => {
     booking_date: moment().format("YYYY-MM-DD"),
     booking_type: BookingType.SEPA_CREDIT_TRANSFER,
     amount: {
-      value: -Math.abs(standingOrder.amount.value)
-    }
+      value: -Math.abs(standingOrder.amount.value),
+    },
   };
 };
 
@@ -360,7 +386,7 @@ export const processQueuedBooking = async (
 
   const isDirectDebit = [
     BookingType.DIRECT_DEBIT,
-    BookingType.SEPA_DIRECT_DEBIT
+    BookingType.SEPA_DIRECT_DEBIT,
   ].includes(booking.booking_type);
 
   const wouldOverdraw =
@@ -386,8 +412,8 @@ export const processQueuedBooking = async (
         amount: {
           value: booking.amount.value,
           unit: "cents",
-          currency: "EUR"
-        }
+          currency: "EUR",
+        },
       };
     }
 
@@ -436,7 +462,7 @@ export const generateBookingForPerson = (bookingData) => {
     transactionId,
     bookingDate,
     valutaDate,
-    status
+    status,
   } = bookingData;
 
   const recipientName = `${person.salutation} ${person.first_name} ${person.last_name}`;
@@ -466,7 +492,7 @@ export const generateBookingForPerson = (bookingData) => {
     booking_type: bookingType,
     transaction_id: transactionId || uuid.v4(),
     return_transaction_id: null,
-    status
+    status,
   };
 };
 
@@ -490,7 +516,7 @@ export const queueBookingRequestHandler = async (req, res) => {
     transactionId,
     bookingDate,
     valutaDate,
-    status
+    status,
   } = req.body;
 
   senderName = senderName || "mocksolaris";
@@ -510,7 +536,7 @@ export const queueBookingRequestHandler = async (req, res) => {
     transactionId,
     bookingDate,
     valutaDate,
-    status
+    status,
   });
 
   person.queuedBookings.push(queuedBooking);
@@ -565,10 +591,10 @@ export const createDirectDebitReturn = async (personId, id) => {
     amount: {
       value: -directDebit.amount.value,
       unit: "cents",
-      currency: "EUR"
+      currency: "EUR",
     },
     booking_date: today,
-    valuta_date: today
+    valuta_date: today,
   };
 
   person.transactions.push(directDebitReturn);
@@ -592,7 +618,7 @@ export const updateAccountLockingStatus = async (personId, lockingStatus) => {
 
   person.account = {
     ...person.account,
-    locking_status: lockingStatus
+    locking_status: lockingStatus,
   };
 
   await savePerson(person);
@@ -612,7 +638,7 @@ const changeCardStatusAllowed = async (personId, cardId, newCardStatus) => {
   const cardData = person.account.cards.find(({ card }) => card.id === cardId);
 
   const {
-    card: { status: currentCardStatus, type }
+    card: { status: currentCardStatus, type },
   } = cardData;
 
   if (
@@ -636,7 +662,7 @@ const changeCardStatusAllowed = async (personId, cardId, newCardStatus) => {
       CardStatus.INACTIVE,
       CardStatus.PROCESSING,
       CardStatus.CLOSED,
-      CardStatus.CLOSED_BY_SOLARIS
+      CardStatus.CLOSED_BY_SOLARIS,
     ].includes(cardData.card.status)
   ) {
     throw new Error(
@@ -663,7 +689,7 @@ export const createReservationHandler = async (req, res) => {
     type,
     recipient,
     declineReason,
-    posEntryMode
+    posEntryMode,
   } = req.body;
 
   if (!personId) {
@@ -682,7 +708,7 @@ export const createReservationHandler = async (req, res) => {
     type,
     recipient,
     declineReason,
-    posEntryMode
+    posEntryMode,
   };
 
   const reservation = await (type === TransactionType.CREDIT_PRESENTMENT
@@ -712,7 +738,7 @@ export const updateReservationHandler = async (req, res) => {
     personId,
     reservationId,
     action,
-    increaseAmount
+    increaseAmount,
   });
 
   res.redirect("back");

--- a/src/templates/person.html
+++ b/src/templates/person.html
@@ -562,6 +562,7 @@
       <td>{{ identification.reference }}</td>
       <td>
         <form class="form-inline autosubmitonchange" method="POST" action="/__BACKOFFICE__/setIdentificationState/{{ person.email }}?method={{ identification.method }}">
+          <input type="hidden" name="skipSettingScreeningValues"value="true" />
           <select name="status">
               <option {% if identification.status === "pending" %}selected {% endif %}value="pending">pending</option>
               <option {% if identification.status === "pending_successful" %}selected {% endif %}value="pending_successful">pending_successful</option>

--- a/src/templates/person.html
+++ b/src/templates/person.html
@@ -562,7 +562,7 @@
       <td>{{ identification.reference }}</td>
       <td>
         <form class="form-inline autosubmitonchange" method="POST" action="/__BACKOFFICE__/setIdentificationState/{{ person.email }}?method={{ identification.method }}">
-          <input type="hidden" name="skipSettingScreeningValues"value="true" />
+          <input type="hidden" name="skipSettingScreeningValues" value="true" />
           <select name="status">
               <option {% if identification.status === "pending" %}selected {% endif %}value="pending">pending</option>
               <option {% if identification.status === "pending_successful" %}selected {% endif %}value="pending_successful">pending_successful</option>


### PR DESCRIPTION
Screening progress won't be updated to a green value automatically when the user manually changes identification status to IdentificationStatus.SUCCESSFUL or IdentificationStatus.PENDING_SUCCESSFUL

On setIdentificationStatus endpoint, it is possible to skip setting screening values so that e2e tests can test different screening values

Introduced a new endpoint to set screening values for e2e tests