### PR TITLE
WANN-531: Adds Seizure Protection section to mock solaris backoffice

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ curl TODO
 
 ## Backoffice screenshots
 
-![mockSolarisPerson](https://user-images.githubusercontent.com/6367201/179481833-0d7087cc-1682-435d-94f5-ed316140eaa2.png)
+![mockSolarisPerson](https://user-images.githubusercontent.com/47757191/189340823-2b200e6f-5068-4a32-8936-9b7b4d7ae38e.png)
 
 
 ### Persons and accounts
@@ -61,6 +61,16 @@ You can set screening values from the "Person data" section ([More info](https:/
 
 <img width="532" alt="Screen Shot 2022-07-18 at 11 38 55 AM" src="https://user-images.githubusercontent.com/6367201/179475427-58af2c02-b229-4cab-96a2-089f45356e60.png">
 
+### Seizure Protection
+When querying the balance for P-konto accounts, you will get a `seizure_protection` object as stated in this [API](https://docs.solarisgroup.com/api-reference/digital-banking/account-management/#tag/Accounts/paths/~1v1~1accounts~1{account_id}~1balance/get). Since solaris does not support changing an account to P-konto; we mocked the existence of seizure protection. 
+
+You can modify the values of seizure protection in this section:
+
+![seizure-protection](https://user-images.githubusercontent.com/47757191/189342102-a69a6a30-bc25-4fc1-bf9a-ba6ee45a76ff.png)
+
+You can also delete the object afterwards:
+
+![allow-delete-seizure-protection](https://user-images.githubusercontent.com/47757191/189342305-284ebf13-af56-4166-b71a-8591eea0f82a.png)
 
 ## Configuration
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.39",
+  "version": "1.0.50",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.39",
+      "version": "1.0.50",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",
@@ -1753,9 +1753,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "engines": [
-        "node >=0.6.0"
-      ]
+      "engines": ["node >=0.6.0"]
     },
     "node_modules/eyes": {
       "version": "0.1.8",
@@ -1929,9 +1927,7 @@
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -2936,9 +2932,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "engines": [
-        "node >=0.6.0"
-      ],
+      "engines": ["node >=0.6.0"],
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -5251,9 +5245,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "engines": [
-        "node >=0.6.0"
-      ],
+      "engines": ["node >=0.6.0"],
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.52",
+      "version": "1.0.53",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -605,6 +605,12 @@ app.post(
   safeRequestHandler(standingOrdersAPI.triggerStandingOrderRequestHandler)
 );
 
+// BACKOFFICE - SEIZURES PROTECTION
+app.post(
+  "/__BACKOFFICE__/setAccountAsPKonto/:personId",
+  safeRequestHandler(backofficeAPI.setAccountIsPKontoFlagHandler)
+);
+
 // BACKOFFICE - SEIZURES
 app.post(
   "/__BACKOFFICE__/createSeizure/:person_id",

--- a/src/app.ts
+++ b/src/app.ts
@@ -607,8 +607,12 @@ app.post(
 
 // BACKOFFICE - SEIZURES PROTECTION
 app.post(
-  "/__BACKOFFICE__/setAccountSeizureProtection/:email",
-  safeRequestHandler(backofficeAPI.setAccountSeizureProtectionHandler)
+  "/__BACKOFFICE__/addAccountSeizureProtection/:email",
+  safeRequestHandler(backofficeAPI.addAccountSeizureProtectionHandler)
+);
+app.post(
+  "/__BACKOFFICE__/deleteAccountSeizureProtection/:email",
+  safeRequestHandler(backofficeAPI.deleteAccountSeizureProtectionHandler)
 );
 
 // BACKOFFICE - SEIZURES

--- a/src/app.ts
+++ b/src/app.ts
@@ -607,8 +607,8 @@ app.post(
 
 // BACKOFFICE - SEIZURES PROTECTION
 app.post(
-  "/__BACKOFFICE__/setAccountIsPkonto/:personId",
-  safeRequestHandler(backofficeAPI.setAccountIsPkontoFlagHandler)
+  "/__BACKOFFICE__/setAccountSeizureProtection/:personId",
+  safeRequestHandler(backofficeAPI.setAccountSeizureProtectionHandler)
 );
 
 // BACKOFFICE - SEIZURES

--- a/src/app.ts
+++ b/src/app.ts
@@ -607,8 +607,8 @@ app.post(
 
 // BACKOFFICE - SEIZURES PROTECTION
 app.post(
-  "/__BACKOFFICE__/setAccountIsPKonto/:personId",
-  safeRequestHandler(backofficeAPI.setAccountIsPKontoFlagHandler)
+  "/__BACKOFFICE__/setAccountIsPkonto/:personId",
+  safeRequestHandler(backofficeAPI.setAccountIsPkontoFlagHandler)
 );
 
 // BACKOFFICE - SEIZURES

--- a/src/app.ts
+++ b/src/app.ts
@@ -607,7 +607,7 @@ app.post(
 
 // BACKOFFICE - SEIZURES PROTECTION
 app.post(
-  "/__BACKOFFICE__/setAccountSeizureProtection/:personId",
+  "/__BACKOFFICE__/setAccountSeizureProtection/:email",
   safeRequestHandler(backofficeAPI.setAccountSeizureProtectionHandler)
 );
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -607,7 +607,7 @@ app.post(
 
 // BACKOFFICE - SEIZURES PROTECTION
 app.post(
-  "/__BACKOFFICE__/setAccountAsPKonto/:personId",
+  "/__BACKOFFICE__/setAccountIsPKonto/:personId",
   safeRequestHandler(backofficeAPI.setAccountIsPKontoFlagHandler)
 );
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -3,7 +3,11 @@ import Promise from "bluebird";
 
 import * as log from "./logger";
 import { calculateOverdraftInterest } from "./helpers/overdraft";
-import { CustomerVettingStatus, RiskClarificationStatus, ScreeningProgress } from "./helpers/types";
+import {
+  CustomerVettingStatus,
+  RiskClarificationStatus,
+  ScreeningProgress,
+} from "./helpers/types";
 
 let redis;
 
@@ -111,6 +115,7 @@ export const migrate = async () => {
         available_balance: {
           value: 100,
         },
+        is_pkonto: false,
       },
       billing_account: {
         id: process.env.SOLARIS_KONTIST_BILLING_ACCOUNT_ID,

--- a/src/db.ts
+++ b/src/db.ts
@@ -136,25 +136,6 @@ export const migrate = async () => {
   }
 };
 
-const DEFAULT_SEIZURE_PROTECTION = {
-  current_blocked_amount: {
-    value: 10000,
-    currency: "EUR",
-    unit: "cents",
-  },
-  protected_amount: {
-    value: 5000,
-    currency: "EUR",
-    unit: "cents",
-  },
-  protected_amount_expiring: {
-    value: 0,
-    currency: "EUR",
-    unit: "cents",
-  },
-  protected_amount_expiring_date: "2022-07-31",
-};
-
 const jsonToPerson = (value) => {
   if (!value) {
     throw new Error("did not find person");

--- a/src/db.ts
+++ b/src/db.ts
@@ -116,6 +116,7 @@ export const migrate = async () => {
           value: 100,
         },
         is_pkonto: false,
+        seizure_protection: null,
       },
       billing_account: {
         id: process.env.SOLARIS_KONTIST_BILLING_ACCOUNT_ID,
@@ -134,6 +135,25 @@ export const migrate = async () => {
       },
     });
   }
+};
+
+const DEFAULT_SEIZURE_PROTECTION = {
+  current_blocked_amount: {
+    value: 10000,
+    currency: "EUR",
+    unit: "cents",
+  },
+  protected_amount: {
+    value: 5000,
+    currency: "EUR",
+    unit: "cents",
+  },
+  protected_amount_expiring: {
+    value: 0,
+    currency: "EUR",
+    unit: "cents",
+  },
+  protected_amount_expiring_date: "2022-07-31",
 };
 
 const jsonToPerson = (value) => {
@@ -195,6 +215,8 @@ export const savePerson = async (person, skipInterest = false) => {
         confirmedTransfersBalance -
         reservationsBalance,
     };
+
+    account.seizure_protection =  account.is_pkonto ? DEFAULT_SEIZURE_PROTECTION : null;
 
     person.account = account;
     person.timedOrders = person.timedOrders || [];

--- a/src/db.ts
+++ b/src/db.ts
@@ -115,7 +115,6 @@ export const migrate = async () => {
         available_balance: {
           value: 100,
         },
-        is_pkonto: false,
         seizure_protection: null,
       },
       billing_account: {
@@ -215,8 +214,6 @@ export const savePerson = async (person, skipInterest = false) => {
         confirmedTransfersBalance -
         reservationsBalance,
     };
-
-    account.seizure_protection =  account.is_pkonto ? DEFAULT_SEIZURE_PROTECTION : null;
 
     person.account = account;
     person.timedOrders = person.timedOrders || [];

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -209,7 +209,6 @@ export enum AccountWebhookEvent {
   "ACCOUNT_BLOCK" = "ACCOUNT_BLOCK",
   "ACCOUNT_CLOSURE" = "ACCOUNT_CLOSURE",
   "ACCOUNT_LIMIT_CHANGE" = "ACCOUNT_LIMIT_CHANGE",
-  "ACCOUNT_PKONTO_CHANGE" = "ACCOUNT_PKONTO_CHANGE",
 }
 
 export enum ProvisioningTokenEventType {

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -209,6 +209,7 @@ export enum AccountWebhookEvent {
   "ACCOUNT_BLOCK" = "ACCOUNT_BLOCK",
   "ACCOUNT_CLOSURE" = "ACCOUNT_CLOSURE",
   "ACCOUNT_LIMIT_CHANGE" = "ACCOUNT_LIMIT_CHANGE",
+  "ACCOUNT_PKONTO_CHANGE" = "ACCOUNT_PKONTO_CHANGE",
 }
 
 export enum ProvisioningTokenEventType {

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -30,7 +30,6 @@ const DEFAULT_ACCOUNT = {
   person_id: "66a692fdddc32c05ebe1c1f1c3145a3bcper",
   status: "ACTIVE",
   closure_reasons: null,
-  is_pkonto: false,
   seizure_protection: null,
 };
 

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -30,26 +30,10 @@ const DEFAULT_ACCOUNT = {
   person_id: "66a692fdddc32c05ebe1c1f1c3145a3bcper",
   status: "ACTIVE",
   closure_reasons: null,
+  is_pkonto: false,
+  seizure_protection: null,
 };
 
-const DEFAULT_SEIZURE_PROTECTION = {
-  current_blocked_amount: {
-    value: 10000,
-    currency: "EUR",
-    unit: "cents",
-  },
-  protected_amount: {
-    value: 5000,
-    currency: "EUR",
-    unit: "cents",
-  },
-  protected_amount_expiring: {
-    value: 0,
-    currency: "EUR",
-    unit: "cents",
-  },
-  protected_amount_expiring_date: "2022-07-31",
-};
 const requestAccountFields = [
   "id",
   "iban",
@@ -221,18 +205,11 @@ export const createAccountSnapshot = async (req, res) => {
 export const showAccountBalance = async (req, res) => {
   const { account_id: accountId } = req.params;
   const person = await findPersonByAccountId(accountId);
-  let balance = _.pick(person.account, [
+  const balance = _.pick(person.account, [
     "balance",
     "available_balance",
     "seizure_protection",
   ]);
-
-  if (person.account.is_pkonto && !balance?.seizure_protection) {
-    balance = {
-      ...balance,
-      seizure_protection: DEFAULT_SEIZURE_PROTECTION,
-    };
-  }
 
   res.status(200).send(balance);
 };

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -68,7 +68,8 @@ export const triggerBookingsWebhook = async (solarisAccountId) => {
 };
 
 export const setAccountSeizureProtectionHandler = async (req, res) => {
-  const { personId } = req.params;
+  const { email } = req.params;
+
   const {
     currentBlockedAmount,
     protectedAmount,
@@ -76,9 +77,10 @@ export const setAccountSeizureProtectionHandler = async (req, res) => {
     protectedAmountExpiringDate,
   } = req.body;
 
-  const person = await getPerson(personId);
+  const persons = await getAllPersons();
+  const person = persons.find((item) => item.email === email);
 
-  if (!person.account) return null;
+  if (!person?.account) return null;
 
   person.account = {
     ...person.account,

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -67,7 +67,7 @@ export const triggerBookingsWebhook = async (solarisAccountId) => {
   await triggerWebhook(TransactionWebhookEvent.BOOKING, payload);
 };
 
-export const setAccountSeizureProtectionHandler = async (req, res) => {
+export const addAccountSeizureProtectionHandler = async (req, res) => {
   const { email } = req.params;
 
   const {
@@ -105,7 +105,34 @@ export const setAccountSeizureProtectionHandler = async (req, res) => {
   };
 
   await savePerson(person);
-  res.redirect("back");
+
+  if (shouldReturnJSON(req)) {
+    res.status(200).send(person.account);
+  } else {
+    res.redirect("back");
+  }
+};
+
+export const deleteAccountSeizureProtectionHandler = async (req, res) => {
+  const { email } = req.params;
+
+  const persons = await getAllPersons();
+  const person = persons.find((item) => item.email === email);
+
+  if (!person?.account) return null;
+
+  person.account = {
+    ...person.account,
+    seizure_protection: null,
+  };
+
+  await savePerson(person);
+
+  if (shouldReturnJSON(req)) {
+    res.status(204).send();
+  } else {
+    res.redirect("back");
+  }
 };
 
 /**

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -78,7 +78,7 @@ export const setAccountIsPKontoFlag = async (personId, isPKonto) => {
 
   person.account = person.account || {};
 
-  const previousIsPKonto = person.account.isPKonto;
+  const previousIsPKonto = person.account.is_pkonto;
 
   person.account = {
     ...person.account,

--- a/src/templates/person.html
+++ b/src/templates/person.html
@@ -197,10 +197,10 @@
     <div class="panel panel-default">
       <div class="panel-heading"><h4>Seizure Protection</h4></div>
       <div class="panel-body">
-          <form method="POST" action="/__BACKOFFICE__/setAccountIsPKonto/{{ person.id }}">
+          <form method="POST" action="/__BACKOFFICE__/setAccountIsPkonto/{{ person.id }}">
             <div class="form-group">
-              <label for="isPKonto">Is account P-Konto?</label>
-              <select name="isPKonto" class="form-control">
+              <label for="isPkonto">Is account P-Konto?</label>
+              <select name="isPkonto" class="form-control">
                 <option {% if person.account.is_pkonto === true %}selected {% endif %} value="true">Yes</option>
                 <option {% if person.account.is_pkonto === false %}selected {% endif %} value="false">No</option>
               </select>

--- a/src/templates/person.html
+++ b/src/templates/person.html
@@ -197,7 +197,7 @@
     <div class="panel panel-default">
       <div class="panel-heading"><h4>Seizure Protection</h4></div>
       <div class="panel-body">
-          <form method="POST" action="/__BACKOFFICE__/setAccountAsPKonto/{{ person.id }}">
+          <form method="POST" action="/__BACKOFFICE__/setAccountIsPKonto/{{ person.id }}">
             <div class="form-group">
               <label for="isPKonto">Is account P-Konto?</label>
               <select name="isPKonto" class="form-control">

--- a/src/templates/person.html
+++ b/src/templates/person.html
@@ -197,7 +197,7 @@
     <div class="panel panel-default">
       <div class="panel-heading"><h4>Seizure Protection</h4></div>
       <div class="panel-body">
-          <form method="POST" action="/__BACKOFFICE__/setAccountSeizureProtection/{{ person.id }}">
+          <form method="POST" action="/__BACKOFFICE__/setAccountSeizureProtection/{{ person.email }}">
             <div class="form-group">
               <label>Current blocked amount</label>
               <input class="form-control" type="number" name="currentBlockedAmount" placeholder="Current blocked amount (in cents)" autocomplete="off" required min="-10000000" max="10000000" />

--- a/src/templates/person.html
+++ b/src/templates/person.html
@@ -193,6 +193,25 @@
       <i>This person does not have an account.</i>
     {% endif %}
 
+    <!-- Seizures Protection -->
+    <div class="panel panel-default">
+      <div class="panel-heading"><h4>Seizure Protection</h4></div>
+      <div class="panel-body">
+          <form method="POST" action="/__BACKOFFICE__/setAccountAsPKonto/{{ person.id }}">
+            <div class="form-group">
+              <label for="isPKonto">Is account P-Konto?</label>
+              <select name="isPKonto" class="form-control">
+                <option {% if person.account.is_pkonto === true %}selected {% endif %} value="true">Yes</option>
+                <option {% if person.account.is_pkonto === false %}selected {% endif %} value="false">No</option>
+              </select>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block">
+              Save Seizure Protection
+            </button>
+          </form>
+      </div>
+    </div>
+
     <!-- Seizures -->
     <div class="panel panel-default">
       <div class="panel-heading"><h4>Seizures</h4></div>

--- a/src/templates/person.html
+++ b/src/templates/person.html
@@ -197,16 +197,26 @@
     <div class="panel panel-default">
       <div class="panel-heading"><h4>Seizure Protection</h4></div>
       <div class="panel-body">
-          <form method="POST" action="/__BACKOFFICE__/setAccountIsPkonto/{{ person.id }}">
+          <form method="POST" action="/__BACKOFFICE__/setAccountSeizureProtection/{{ person.id }}">
             <div class="form-group">
-              <label for="isPkonto">Is account P-Konto?</label>
-              <select name="isPkonto" class="form-control">
-                <option {% if person.account.is_pkonto === true %}selected {% endif %} value="true">Yes</option>
-                <option {% if person.account.is_pkonto === false %}selected {% endif %} value="false">No</option>
-              </select>
+              <label>Current blocked amount</label>
+              <input class="form-control" type="number" name="currentBlockedAmount" placeholder="Current blocked amount (in cents)" autocomplete="off" required min="-10000000" max="10000000" />
             </div>
+            <div class="form-group">
+              <label>Protected amount</label>
+              <input class="form-control" type="number" name="protectedAmount" placeholder="Protected amount (in cents)" autocomplete="off" required min="-10000000" max="10000000" />
+            </div>
+            <div class="form-group">
+              <label>Protected amount expiring</label>
+              <input class="form-control" type="number" name="protectedAmountExpiring" placeholder="Protected amount expiring (in cents)" autocomplete="off" required min="-10000000" max="10000000" />
+            </div>
+            <div class="form-group">
+              <label>Protected amount expiring Date</label>
+              <input class="form-control" type="date" name="protectedAmountExpiringDate" placeholder="Protected amount expiring date" autocomplete="off" required min="2020-01-01" />
+            </div>
+            <br>
             <button type="submit" class="btn btn-primary btn-block">
-              Save Seizure Protection
+              Save seizure protection
             </button>
           </form>
       </div>

--- a/src/templates/person.html
+++ b/src/templates/person.html
@@ -197,7 +197,35 @@
     <div class="panel panel-default">
       <div class="panel-heading"><h4>Seizure Protection</h4></div>
       <div class="panel-body">
-          <form method="POST" action="/__BACKOFFICE__/setAccountSeizureProtection/{{ person.email }}">
+        {% if person.account.seizure_protection %}
+          <form method="POST" action="/__BACKOFFICE__/deleteAccountSeizureProtection/{{ person.email }}">
+            <div class="alert alert-info">
+              Account is seizure protected!
+            </div>
+            <button type="submit" class="btn btn-danger btn-block">
+              Delete seizure protection
+            </button>
+          </form>
+          <br>
+          <div class="panel-group">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h4 class="panel-title">
+                  <a data-toggle="collapse" href="#seizureProtectionRawData">
+                    Raw seizure protection data
+                  </a>
+                  <span class="caret"></span>
+                </h4>
+              </div>
+              <div id="seizureProtectionRawData" class="panel-collapse collapse">
+                <div class="panel-body">
+                  <pre>{{ JSON.stringify(person.account.seizure_protection, undefined, 2) }}</pre>
+                </div>
+              </div>
+            </div>
+          </div>
+        {% else %}
+          <form method="POST" action="/__BACKOFFICE__/addAccountSeizureProtection/{{ person.email }}">
             <div class="form-group">
               <label>Current blocked amount</label>
               <input class="form-control" type="number" name="currentBlockedAmount" placeholder="Current blocked amount (in cents)" autocomplete="off" required min="-10000000" max="10000000" />
@@ -219,6 +247,7 @@
               Save seizure protection
             </button>
           </form>
+        {% endif %}
       </div>
     </div>
 


### PR DESCRIPTION
Adds Seizure Protection section to mock solaris backoffice

Addresses [WANN-531](https://kontist.atlassian.net/browse/WANN-531)

Adds seizure protection to backoffice in order to mock the account being P-konto and therefore be able to display the seizure protection object in the balance API [solaris account balance API](https://docs.solarisgroup.com/api-reference/digital-banking/account-management/#tag/Accounts/paths/~1v1~1accounts~1{account_id}~1balance/get)

![seizure-protection](https://user-images.githubusercontent.com/47757191/189161793-f222756d-3456-4d92-8e02-9b555549023b.png)

![allow-delete-seizure-protection](https://user-images.githubusercontent.com/47757191/189332673-70503d32-23c6-4ed8-b2b7-eab62a2ff94a.png)
