### PR TITLE
Add container registry CI job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,3 +31,26 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+  publish-docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: kontist
+          password: ${{ github.token }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v2
+        env:
+          IMAGE_REPOSITORY: ghcr.io/kontist/mock-solaris
+        with:
+          push: true
+          tags: |
+            ${{ env.IMAGE_REPOSITORY }}:latest
+            ${{ env.IMAGE_REPOSITORY }}:${{ github.ref_name }}


### PR DESCRIPTION
Added job to the `publish` CI workflow, that builds and pushes container image to the GitHub Container Registry.