### PR TITLE
Create device monitoring consent returns an object

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.68",
+      "version": "1.0.69",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/routes/deviceMonitoring.ts
+++ b/src/routes/deviceMonitoring.ts
@@ -37,7 +37,7 @@ export const createDeviceConsent = async (
 
   const consent = await db.createDeviceConsent(person.id, deviceConsent);
 
-  res.status(201).send([consent]);
+  res.status(201).send(consent);
 };
 
 export const updateDeviceConsent = async (

--- a/src/routes/deviceMonitoring.ts
+++ b/src/routes/deviceMonitoring.ts
@@ -61,7 +61,7 @@ export const updateDeviceConsent = async (
     deviceConsent
   );
 
-  res.status(201).send([consent]);
+  res.status(201).send(consent);
 };
 
 export const createUserActivity = async (
@@ -80,5 +80,5 @@ export const createUserActivity = async (
 
   const activity = await db.createDeviceActivity(person.id, deviceActivity);
 
-  res.status(201).send([activity]);
+  res.status(201).send(activity);
 };

--- a/tests/deviceMonitoring.spec.ts
+++ b/tests/deviceMonitoring.spec.ts
@@ -67,7 +67,7 @@ describe("device monitoring", () => {
       expect(consent.event_type).to.equal(req.body.event_type);
       expect(consent.confirmed_at).to.equal(req.body.confirmed_at);
       expect(res.status.getCall(0).args[0]).to.equal(201);
-      expect(res.send.getCall(0).args[0].length).to.equal(1);
+      expect(res.send.getCall(0).args[0]).to.deep.equal(consent);
     });
   });
 
@@ -94,7 +94,7 @@ describe("device monitoring", () => {
       expect(activity.device_data).to.equal(req.body.device_data);
       expect(activity.activity_type).to.equal(req.body.activity_type);
       expect(res.status.getCall(0).args[0]).to.equal(201);
-      expect(res.send.getCall(0).args[0].length).to.equal(1);
+      expect(res.send.getCall(0).args[0]).to.deep.equal(activity);
     });
   });
 });

--- a/tests/deviceMonitoring.spec.ts
+++ b/tests/deviceMonitoring.spec.ts
@@ -37,8 +37,7 @@ describe("device monitoring", () => {
       expect(consent.event_type).to.equal(req.body.event_type);
       expect(consent.confirmed_at).to.equal(req.body.confirmed_at);
       expect(res.status.getCall(0).args[0]).to.equal(201);
-      expect(res.send.getCall(0).args[0].length).to.equal(1);
-
+      expect(res.send.getCall(0).args[0]).to.deep.equal(consent);
       deviceConsentId = consent.id;
     });
   });


### PR DESCRIPTION
Instead of an array (according to sb docs)

https://docs.solarisgroup.com/guides/kyc/device-monitoring/#post-create-user-consent-for-device-monitoring