### PR TITLE
Extend card with new field

### DIFF
--- a/src/helpers/cards.ts
+++ b/src/helpers/cards.ts
@@ -234,6 +234,7 @@ export const createCard = (
     expiration_date: expirationDate.format("YYYY-MM-DD"),
     person_id: person.id,
     account_id: person.account.id,
+    new_card_ordered: true,
     business_id: businessId,
     representation: {
       line_1: cardHolder,
@@ -266,7 +267,8 @@ export const replaceCard = (
       ...card.representation,
       line_1: cardData.line_1 || card.representation.line_1,
     },
-    status: CardStatus.PROCESSING,
+    status: CardStatus.ACTIVE,
+    new_card_ordered: true,
   };
 
   const newCardDetails = {
@@ -508,6 +510,7 @@ export const activateCard = async (cardForActivation: Card): Promise<Card> => {
   );
 
   cardForActivation.status = CardStatus.ACTIVE;
+  cardForActivation.new_card_ordered = false;
   person.account.cards[cardIndex].card = cardForActivation;
   await db.savePerson(person);
   await triggerWebhook({

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -80,6 +80,7 @@ export type Card = {
   person_id: string;
   account_id: string;
   business_id: string | null;
+  new_card_ordered: boolean;
   representation: {
     line_1: string;
     formatted_expiration_date: string;


### PR DESCRIPTION
extend mock Solaris with new card field `new_card_ordered`, which is false by default. On card replacement request it should be set to true. Allow to set card status from Processing to Active  in cards ui. After card activation `new_card_ordered` should be flipped to false