### PR TITLE
PersonId 36 char limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.84",
+  "version": "1.0.85.2",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.85-3",
+  "version": "1.0.84",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.85.2",
+  "version": "1.0.85-2",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.85-2",
+  "version": "1.0.85-3",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/routes/persons.ts
+++ b/src/routes/persons.ts
@@ -17,7 +17,7 @@ const format = (date: Moment): string => date.format("YYYY-MM-DD");
  * @see {@link https://docs.solarisgroup.com/api-reference/onboarding/account-creation/#tag/Person-accounts/paths/~1v1~1persons~1{person_id}~1accounts/post}
  */
 export const createPerson = async (req, res) => {
-  const personId = `mock${uuid.v4()}`;
+  const personId = uuid.v4(); // Do not exceed 36 characters
   const createdAt = moment();
 
   const person = {


### PR DESCRIPTION
When we create personIDs of more than 36 characters, db throws due to column size.