### PR TITLE
Add support for timed order change request flow

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.89",
+  "version": "1.0.90",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.89",
+      "version": "1.0.90",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.88",
+  "version": "1.0.89",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.88",
+      "version": "1.0.89",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.88",
+  "version": "1.0.89",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.89",
+  "version": "1.0.90",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -148,6 +148,36 @@ export type BillingAccount = {
   id: string;
 };
 
+export enum TimedOrderStatus {
+  CREATED = "CREATED",
+  AUTHORIZATION_REQUIRED = "AUTHORIZATION_REQUIRED",
+  CONFIRMATION_REQUIRED = "CONFIRMATION_REQUIRED",
+  EXECUTED = "EXECUTED",
+  FAILED = "FAILED",
+  SCHEDULED = "SCHEDULED",
+  CANCELED = "CANCELED",
+}
+
+export type TimedOrder = {
+  id: string;
+  execute_at: string;
+  executed_at: string | null;
+  status: string;
+  scheduled_transaction: {
+    id: string;
+    status: TimedOrderStatus;
+    reference: string;
+    description: string;
+    recipient_iban: string;
+    recipient_name: string;
+    recipient_bic: string;
+    end_to_end_id: string;
+    batch_id: string | null;
+    created_at: string;
+    amount: Amount;
+  };
+};
+
 export type MockChangeRequest = {
   cardId?: string;
   pin?: string;
@@ -159,6 +189,7 @@ export type MockChangeRequest = {
   createdAt: string;
   delta?: Record<string, unknown>;
   transfer?: Record<string, any>;
+  timedOrder?: TimedOrder;
 };
 
 export interface StandingOrder {
@@ -188,6 +219,7 @@ export type MockPerson = {
   postboxItems?: PostboxItem[];
   billing_account?: BillingAccount;
   identifications?: Record<string, unknown>;
+  timedOrders?: TimedOrder[];
 };
 
 export type MockCreatePerson = {

--- a/src/routes/changeRequest.ts
+++ b/src/routes/changeRequest.ts
@@ -237,10 +237,9 @@ export const confirmChangeRequest = async (req, res) => {
       break;
     case TIMED_ORDER_CREATE:
       const { timedOrder } = person.changeRequest;
-      timedOrder.status = TimedOrderStatus.SCHEDULED;
       const order = person.timedOrders.find(({ id }) => id === timedOrder.id);
       order.status = TimedOrderStatus.SCHEDULED;
-      response.response_body = person.changeRequest.timedOrder;
+      response.response_body = order;
       break;
     case BATCH_TRANSFER_CREATE_METHOD:
       response.response_body = await confirmBatchTransfer(

--- a/src/routes/changeRequest.ts
+++ b/src/routes/changeRequest.ts
@@ -37,6 +37,7 @@ import {
   AuthorizeChangeRequestResponse,
   ChangeRequestStatus,
   MockPerson,
+  TimedOrderStatus,
 } from "../helpers/types";
 import { triggerWebhook } from "../helpers/webhooks";
 import {
@@ -235,7 +236,13 @@ export const confirmChangeRequest = async (req, res) => {
       response.response_body = await tinProcessChangeRequest(person);
       break;
     case TIMED_ORDER_CREATE:
-      // TODO: FIX response.response_body = await confirmTimedOrder(person);
+      const { timedOrder } = person.changeRequest;
+      timedOrder.status = TimedOrderStatus.SCHEDULED;
+      const order = person.timedOrders.find(
+        (order) => order.id === timedOrder.id
+      );
+      order.status = TimedOrderStatus.SCHEDULED;
+      response.response_body = person.changeRequest.timedOrder;
       break;
     case BATCH_TRANSFER_CREATE_METHOD:
       response.response_body = await confirmBatchTransfer(

--- a/src/routes/changeRequest.ts
+++ b/src/routes/changeRequest.ts
@@ -238,9 +238,7 @@ export const confirmChangeRequest = async (req, res) => {
     case TIMED_ORDER_CREATE:
       const { timedOrder } = person.changeRequest;
       timedOrder.status = TimedOrderStatus.SCHEDULED;
-      const order = person.timedOrders.find(
-        (order) => order.id === timedOrder.id
-      );
+      const order = person.timedOrders.find(({ id }) => id === timedOrder.id);
       order.status = TimedOrderStatus.SCHEDULED;
       response.response_body = person.changeRequest.timedOrder;
       break;

--- a/src/routes/timedOrders.ts
+++ b/src/routes/timedOrders.ts
@@ -164,7 +164,7 @@ export const createTimedOrder = async (req, res) => {
       method: TIMED_ORDER_CREATE,
       id: crypto.randomBytes(16).toString("hex"),
       createdAt: new Date().toISOString(),
-      timedOrder: timedOrder,
+      timedOrder,
     };
 
     response = {

--- a/src/routes/timedOrders.ts
+++ b/src/routes/timedOrders.ts
@@ -1,6 +1,7 @@
 import uuid from "node-uuid";
 import HttpStatusCodes from "http-status";
 import moment from "moment";
+import crypto from "crypto";
 import * as express from "express";
 
 import { getPerson, savePerson } from "../db";
@@ -119,6 +120,7 @@ export const createTimedOrder = async (req, res) => {
   const person = await getPerson(personId);
 
   const {
+    change_request_enabled: changeRequestEnabled,
     execute_at: executeAt,
     transaction: {
       recipient_name: recipientName,
@@ -154,9 +156,31 @@ export const createTimedOrder = async (req, res) => {
 
   const timedOrder = generateTimedOrder(body);
   person.timedOrders.push(timedOrder);
-  await savePerson(person);
 
-  res.status(HttpStatusCodes.CREATED).send(timedOrder);
+  let response = timedOrder;
+
+  if (changeRequestEnabled) {
+    person.changeRequest = {
+      method: TIMED_ORDER_CREATE,
+      id: crypto.randomBytes(16).toString("hex"),
+      createdAt: new Date().toISOString(),
+      timedOrder: timedOrder,
+    };
+
+    response = {
+      id: person.changeRequest.id,
+      status: "AUTHORIZATION_REQUIRED",
+      updated_at: person.changeRequest.createdAt,
+      url: ":env/v1/change_requests/:id/authorize",
+    } as any;
+  }
+
+  await savePerson(person);
+  const responseStatus = changeRequestEnabled
+    ? HttpStatusCodes.ACCEPTED
+    : HttpStatusCodes.CREATED;
+
+  res.status(responseStatus).send(response);
 };
 
 export const authorizeTimedOrder = async (req, res) => {

--- a/tests/routes/timedOrders.spec.ts
+++ b/tests/routes/timedOrders.spec.ts
@@ -1,0 +1,109 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import { mockReq, mockRes } from "sinon-express-mock";
+
+import * as db from "../../src/db";
+
+import * as timedOrdersApi from "../../src/routes/timedOrders";
+import { createPerson } from "../../src/routes/persons";
+import * as changeRequestApi from "../../src/routes/changeRequest";
+import { DeliveryMethod } from "../../src/helpers/types";
+
+describe("Timed Orders", () => {
+  describe("createTimedOrder", () => {
+    let res: sinon.SinonSpy;
+    let personId: string;
+    let changeRequestId: string;
+
+    before(async () => {
+      await db.flushDb();
+      res = mockRes();
+      await createPerson(
+        {
+          body: {},
+          headers: {},
+        },
+        res
+      );
+
+      personId = res.send.args[0][0].id;
+
+      const req = mockReq({
+        params: {
+          person_id: personId,
+        },
+        body: {
+          change_request_enabled: true,
+          execute_at: "2021-01-01T00:00:00.000Z",
+          transaction: {
+            recipient_name: "John Doe",
+            recipient_iban: "DE89370400440532013000",
+            reference: "Test",
+            amount: {
+              value: 100,
+              unit: "cents",
+              currency: "EUR",
+            },
+          },
+        },
+      });
+
+      await timedOrdersApi.createTimedOrder(req, res);
+    });
+
+    it("should return confirmation id", async () => {
+      const lastCall = res.send.args[res.send.args.length - 1];
+      changeRequestId = lastCall[0].id;
+      expect(changeRequestId).to.be.a("string");
+    });
+
+    it("should create a timed order", async () => {
+      const person = await db.getPerson(personId);
+      expect(person.timedOrders).to.have.length(1);
+      expect(person.changeRequest).to.be.an("object");
+    });
+
+    describe("confirmTimedOrder by change request flow", () => {
+      it("should return timed order", async () => {
+        const changeReq = mockReq({
+          params: {
+            change_request_id: changeRequestId,
+          },
+          body: {
+            person_id: personId,
+            delivery_method: DeliveryMethod.MOBILE_NUMBER,
+          },
+        });
+        await changeRequestApi.authorizeChangeRequest(changeReq, res);
+
+        let person = await db.getPerson(personId);
+        const tan = person.changeRequest.token;
+
+        const confirmReq = mockReq({
+          params: {
+            change_request_id: changeRequestId,
+          },
+          body: {
+            person_id: personId,
+            tan,
+          },
+        });
+        await changeRequestApi.confirmChangeRequest(confirmReq, res);
+
+        const response = res.send.args[res.send.args.length - 1][0];
+        expect(response.status).to.equal("COMPLETED");
+        expect(response.id).to.equal(changeRequestId);
+        expect(response.response_body).to.be.an("object");
+        expect(response.response_body.status).to.equal("SCHEDULED");
+        expect(response.response_body.scheduled_transaction).to.be.an("object");
+
+        person = await db.getPerson(personId);
+        expect(person.changeRequest).to.be.undefined;
+        expect(person.timedOrders).to.have.length(1);
+        expect(person.timedOrders[0].status).to.equal("SCHEDULED");
+      });
+    });
+  });
+
+  after(db.flushDb);
+});


### PR DESCRIPTION
Current flow is deprecated:

https://docs.solarisgroup.com/api-reference/digital-banking/sepa-transfers/#tag/Timed-orders/paths/~1v1~1persons~1{person_id}~1accounts~1{account_id}~1timed_orders/post