### PR TITLE
Fix stripe error when no payment method

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.95",
+  "version": "1.0.96",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.95",
+      "version": "1.0.96",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.95",
+  "version": "1.0.96",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/routes/topUps.ts
+++ b/src/routes/topUps.ts
@@ -44,7 +44,7 @@ export const createTopUp = async (req: RequestWithPerson, res: Response) => {
     automatic_payment_methods: {
       enabled: true,
     },
-    payment_method: paymentMethodId || null,
+    ...(paymentMethodId ? { payment_method: paymentMethodId } : {}),
   });
 
   res.send(mapPaymentIntentToTopUp(paymentIntent));


### PR DESCRIPTION
When we pass null we get an error from Stripe:

You passed an empty string for &#39;payment_method&#39;. We assume empty values are an attempt to unset a parameter; however &#39;payment_method&#39; cannot be unset. You should remove &#39;payment_method&#39; from your request or supply a non-empty value.