### PR TITLE
Add Kontist account to sorted set

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.102",
+      "version": "1.0.103",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/helpers/persons.ts
+++ b/src/helpers/persons.ts
@@ -1,0 +1,11 @@
+import moment from "moment";
+import { MockPerson } from "./types";
+import { redisClient } from "../db";
+
+export const storePersonInSortedSet = async (person: MockPerson) => {
+  const score = moment(person.createdAt).valueOf();
+  // Use zAdd to add the person to the sorted set
+  const key = `${process.env.MOCKSOLARIS_REDIS_PREFIX}:persons`;
+  const member = { score, value: person.id };
+  await redisClient.zAdd(key, member);
+};

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -142,10 +142,21 @@ export type MockAccount = {
   locking_status: string;
   iban: string;
   available_balance?: Amount;
+  bic: string;
+  type: string;
+  person_id: string;
+  seizure_protection?: Record<string, unknown>;
 };
 
 export type BillingAccount = {
   id: string;
+  iban: string;
+  bic: string;
+  type: string;
+  person_id: string;
+  balance: Amount;
+  available_balance: Amount;
+  locking_status: string;
 };
 
 export enum TimedOrderStatus {
@@ -209,6 +220,7 @@ export type PostboxItem = {
 export type MockPerson = {
   id: string;
   email: string;
+  createdAt: string;
   fraudCases?: FraudCase[];
   account?: MockAccount;
   transactions: Booking[];
@@ -223,6 +235,23 @@ export type MockPerson = {
   stripeCustomerId?: string;
   first_name: string;
   last_name: string;
+  salutation?: string;
+  birth_date?: string;
+  birth_city?: string;
+  nationality?: string;
+  employment_status?: string;
+  birth_country?: string;
+  address?: {
+    line_1: string;
+    postal_code: string;
+    city: string;
+    country: string;
+  };
+  fatca_relevant?: boolean;
+  mobile_number?: string;
+  screening_progress?: ScreeningProgress;
+  risk_classification_status?: RiskClarificationStatus;
+  customer_vetting_status?: CustomerVettingStatus;
 };
 
 export type MockCreatePerson = {
@@ -412,6 +441,7 @@ export type Booking = {
   booking_date: string;
   booking_type: string;
   amount: Amount;
+  name?: string;
   description: string;
   recipient_bic: string;
   recipient_iban: string;

--- a/src/routes/backoffice.ts
+++ b/src/routes/backoffice.ts
@@ -54,6 +54,7 @@ import {
   issueInterestAccruedBooking,
 } from "../helpers/overdraft";
 import generateID from "../helpers/id";
+import { storePersonInSortedSet } from "../helpers/persons";
 
 const triggerIdentificationWebhook = (payload, personId?: string) =>
   triggerWebhook({
@@ -889,11 +890,7 @@ export const createMaps = async (req, res) => {
 
     let sortedPersons = 0;
     for (const person of persons) {
-      const score = moment(person.createdAt).valueOf();
-      // Use zAdd to add the person to the sorted set
-      const key = `${process.env.MOCKSOLARIS_REDIS_PREFIX}:persons`;
-      const member = { score, value: person.id };
-      await redisClient.zAdd(key, member);
+      await storePersonInSortedSet(person);
       sortedPersons++;
     }
 

--- a/src/routes/persons.ts
+++ b/src/routes/persons.ts
@@ -14,6 +14,7 @@ import { createChangeRequest } from "./changeRequest";
 import { triggerWebhook } from "../helpers/webhooks";
 import { MockPerson, PersonWebhookEvent } from "../helpers/types";
 import generateID from "../helpers/id";
+import { storePersonInSortedSet } from "../helpers/persons";
 
 const format = (date: Moment): string => date.format("YYYY-MM-DD");
 
@@ -45,11 +46,7 @@ export const createPerson = async (req, res) => {
     });
   });
 
-  // Add the person's createdAt timestamp to a sorted set in Redis
-  const score = createdAt.valueOf();
-  const key = `${process.env.MOCKSOLARIS_REDIS_PREFIX}:persons`;
-  const member = { score, value: person.id };
-  await redisClient.zAdd(key, member);
+  await storePersonInSortedSet(person);
 
   if (person.account?.id) {
     await saveAccountToPersonId(person.account, personId);

--- a/tests/mockData.ts
+++ b/tests/mockData.ts
@@ -44,6 +44,7 @@ export const mockAmount: Amount = {
 
 export const mockAccount: MockAccount = {
   id: "account1",
+  bic: "SOBKDEBBXXX",
   reservations: [],
   fraudReservations: [],
   pendingReservation: mockReservation,
@@ -53,6 +54,8 @@ export const mockAccount: MockAccount = {
   iban: "DE12345678901234567890",
   locking_status: "",
   cards: [],
+  person_id: "",
+  type: "CHECKING_PERSONAL",
 };
 
 export const mockCreatePerson: MockCreatePerson = {


### PR DESCRIPTION
In tests we are calling MockSolaris.migrate(). This creates Kontist person with some default data. This call was missing adding person to sorted set, because of that MockSolaris.getAllPersons() were returning an empty array after migration call (when it should return Kontist person)