### PR TITLE
Fix mock crash

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.103",
+  "version": "1.0.105",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.103",
+      "version": "1.0.105",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.104",
+  "version": "1.0.105",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/tests/db.spec.ts
+++ b/tests/db.spec.ts
@@ -47,6 +47,21 @@ describe("getPersons()", async () => {
     expect(persons[0].email).to.equal(`user${numPersons}@kontist.com`);
   });
 
+  it(`findPersons() filter when cb function is provided, but not limit`, async () => {
+    const req = mockReq({
+      body: {
+        email: `superuser@kontist.com`,
+      },
+      headers,
+    });
+    const res = mockRes();
+    await createPerson(req, res);
+    const persons = await findPersons({
+      callbackFn: (person) => person.email.endsWith("@kontist.com"),
+    });
+    expect(persons.length).to.equal(1);
+  });
+
   it("findPerson() returns a person if the person is found", async () => {
     const email = `person@person.com`;
     const req = mockReq({


### PR DESCRIPTION
Due to how default params are provided, in case of calling `findPersons` with callbackFn only, limit became undefined