### PR TITLE
Fix instant credit change request response

### DIFF
--- a/src/routes/changeRequest.ts
+++ b/src/routes/changeRequest.ts
@@ -45,7 +45,10 @@ import {
   confirmCardTransaction,
   declineCardTransaction,
 } from "../helpers/scaChallenge";
-import {DIRECT_DEBIT_REFUND_METHOD, SEPA_TRANSFER_METHOD} from "./transactions";
+import {
+  DIRECT_DEBIT_REFUND_METHOD,
+  SEPA_TRANSFER_METHOD,
+} from "./transactions";
 import {
   INSTANT_CREDIT_TRANSFER_CREATE,
   confirmInstantCreditTransfer,
@@ -243,9 +246,7 @@ export const confirmChangeRequest = async (req, res) => {
       response.response_body = order;
       break;
     case INSTANT_CREDIT_TRANSFER_CREATE:
-      const {instantCreditTransfer} = person.changeRequest;
-      await confirmInstantCreditTransfer(person);
-      response.response_body = {id: instantCreditTransfer.id};
+      response.response_body = await confirmInstantCreditTransfer(person);
       break;
     case BATCH_TRANSFER_CREATE_METHOD:
       response.response_body = await confirmBatchTransfer(

--- a/src/routes/instantCreditTransfer.ts
+++ b/src/routes/instantCreditTransfer.ts
@@ -153,4 +153,6 @@ export const confirmInstantCreditTransfer = async (person) => {
 
   await savePerson(person);
   await triggerBookingsWebhook(person);
+
+  return instantCreditTransfer;
 };


### PR DESCRIPTION
We get error(`amount.value undefined`) on backend after creating new instant transfer. Expected response is returned from  change request confirm.