### PR TITLE
Fix account_opening webhook

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.126",
+  "version": "1.0.127",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.126",
+      "version": "1.0.127",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.126",
+  "version": "1.0.127",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/helpers/webhooks.ts
+++ b/src/helpers/webhooks.ts
@@ -82,6 +82,8 @@ const WEBHOOK_SECRETS = {
     process.env.SOLARIS_ACCOUNT_LIMIT_CHANGE_WEBHOOK_SECRET,
   [PostboxItemEvent.POSTBOX_ITEM_CREATED]:
     process.env.SOLARIS_POSTBOX_ITEM_CREATED_WEBHOOK_SECRET,
+  [PersonWebhookEvent.ACCOUNT_OPENING_REQUEST]:
+    process.env.SOLARIS_ACCOUNT_OPENING_REQUEST_WEBHOOK_SECRET,
 };
 
 export const getWebhookUrl = (url: string, origin?: string) => {

--- a/src/routes/accountOpeningRequest.ts
+++ b/src/routes/accountOpeningRequest.ts
@@ -85,6 +85,7 @@ export const createAccountOpeningRequest = async (
 
   await triggerWebhook({
     type: PersonWebhookEvent.ACCOUNT_OPENING_REQUEST,
+    personId: person.id,
     payload: {
       account_opening_request_id: completedRequest.id,
       customer_id: completedRequest.customer_id,


### PR DESCRIPTION
we discard the webhook without a secret, that's why it was broken on develop when ACCOUNT_OPENING_REQUEST feature flag was on