### PR TITLE
MOCKSOLARIS_DISABLE_IDNOW_TESTSERVER only when "true"

### DIFF
--- a/src/routes/identifications.ts
+++ b/src/routes/identifications.ts
@@ -56,7 +56,7 @@ export const patchIdentification = async (req, res) => {
     identificationUrl = `https://go.test.idnow.de/kontist/identifications/${identificationId}`;
     startUrl = `https://api.test.idnow.de/api/v1/kontist/identifications/${identificationId}/start`;
 
-    if (!process.env.MOCKSOLARIS_DISABLE_IDNOW_TESTSERVER) {
+    if (process.env.MOCKSOLARIS_DISABLE_IDNOW_TESTSERVER !== "true") {
       const response = await fetch(createUrl, {
         method: "POST",
         headers: {


### PR DESCRIPTION
It creates confustion, when set to string `false` it was still treated as true case