### PR TITLE
KRP-1137 Add missing fields for business registry response

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.135",
+  "version": "1.0.136",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.135",
+      "version": "1.0.136",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.135",
+  "version": "1.0.136",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/fixtures/businesses.ts
+++ b/src/fixtures/businesses.ts
@@ -15,6 +15,13 @@ export const businesses: Business[] = [
     tax_country: "DE",
     registration_number: "HRB 198673",
     registration_issuer: "AMTSGERICHT MÜNCHEN",
+    registration_date: "2021-01-01",
+    legal_representatives: [
+      {
+        first_name: "Max",
+        last_name: "Mustermann",
+      },
+    ],
   },
   {
     name: "FLOOR 14 GmbH",
@@ -30,6 +37,13 @@ export const businesses: Business[] = [
     tax_country: "DE",
     registration_number: "HRB 198674",
     registration_issuer: "ISSUER MÜNCHEN",
+    registration_date: "2022-01-01",
+    legal_representatives: [
+      {
+        first_name: "John",
+        last_name: "Doer",
+      },
+    ],
   },
   {
     name: "COMPANY 15 GmbH",
@@ -45,6 +59,13 @@ export const businesses: Business[] = [
     tax_country: "DE",
     registration_number: "HRB 198674",
     registration_issuer: "ISSUER BAVARIA",
+    registration_date: "2023-01-01",
+    legal_representatives: [
+      {
+        first_name: "Jane",
+        last_name: "Doe",
+      },
+    ],
   },
   {
     name: "COMPANY 16 GmbH",
@@ -60,5 +81,12 @@ export const businesses: Business[] = [
     tax_country: "DE",
     registration_number: "HRB 198674",
     registration_issuer: "ISSUER SAXONY",
+    registration_date: "2023-01-01",
+    legal_representatives: [
+      {
+        first_name: "Jane",
+        last_name: "Doer",
+      },
+    ],
   },
 ];

--- a/src/routes/commercialRegistrations/find.ts
+++ b/src/routes/commercialRegistrations/find.ts
@@ -49,6 +49,13 @@ export const find = (req: FindRequest, res: FindResponse) => {
       name: businessNames[Math.floor(Math.random() * businessNames.length)],
       registration_number,
       registration_issuer,
+      registration_date: new Date().toISOString().substring(0, 10),
+      legal_representatives: [
+        {
+          first_name: "Max",
+          last_name: "Mustermann",
+        },
+      ],
     };
     return res.status(200).send(mockBusiness);
   } else {

--- a/src/routes/commercialRegistrations/types/business.ts
+++ b/src/routes/commercialRegistrations/types/business.ts
@@ -13,4 +13,6 @@ export type Business = {
   tax_country: Country;
   registration_number: string;
   registration_issuer: string;
+  registration_date: string;
+  legal_representatives: LegalRepresentative[];
 };


### PR DESCRIPTION
We need to show founded date and legal representatives in UI. 

https://linear.app/ageras-group/issue/KRP-1137/business-details-form