### PR TITLE
Assign new tax identifications to business before saving

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.154",
+  "version": "1.0.155",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.154",
+      "version": "1.0.155",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.154",
+  "version": "1.0.155",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/routes/business/taxIdentifications.ts
+++ b/src/routes/business/taxIdentifications.ts
@@ -34,6 +34,8 @@ export const createBusinessTaxIdentification = async (
 
   taxIdentifications.push(newIdent);
 
+  business.taxIdentifications = taxIdentifications;
+
   await saveBusiness(business);
   res.status(201).send(newIdent);
 };
@@ -74,6 +76,8 @@ export const updateBusinessTaxIdentification = async (
     ...taxIdentifications[index],
     ...taxIdentificationToUpdate,
   };
+
+  business.taxIdentifications = taxIdentifications;
 
   await saveBusiness(business);
   res.status(200).send(taxIdentifications[index]);


### PR DESCRIPTION
Due to this line of code, when creating the first taxIdentifiation it would not assign to business, because the empty array is taken, not the object reference of `business.taxIdentifications`.

`const taxIdentifications = business.taxIdentifications || [];`

Thus the first taxId will never be stored on the business.

