### PR TITLE
KRP-1790 Subaccounts bank statements do not work

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.166",
+  "version": "1.0.167",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.166",
+      "version": "1.0.167",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.166",
+  "version": "1.0.167",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/routes/bankStatements.ts
+++ b/src/routes/bankStatements.ts
@@ -161,16 +161,18 @@ export const showBankStatementBookings = async (req, res) => {
   const momentStartDate = moment(startDate);
   const momentEndDate = moment(endDate);
 
-  const bankStatementsBookings = account.transactions
-    .filter((booking) =>
-      moment(booking.booking_date).isBetween(
-        momentStartDate,
-        momentEndDate,
-        null,
-        "[]"
-      )
-    )
-    .slice((number - 1) * size, number * size);
+  const bankStatementsBookings = account?.transactions?.length
+    ? account?.transactions
+        .filter((booking) =>
+          moment(booking.booking_date).isBetween(
+            momentStartDate,
+            momentEndDate,
+            null,
+            "[]"
+          )
+        )
+        .slice((number - 1) * size, number * size)
+    : [];
 
   const logText = person
     ? `person id ${person.id}`


### PR DESCRIPTION
https://linear.app/ageras-new/issue/KRP-1790/[mock-solaris]-subaccounts-bank-statements-do-not-work
It was throwing without transactions

<img width="451" alt="Screenshot 2025-04-11 at 16 00 40" src="https://github.com/user-attachments/assets/e7a12abb-c353-4469-8f81-79cd5c707094" />
