### PR TITLE
[KRP-2183] Verification of payee endpoint

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.170",
+  "version": "1.0.171",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontist/mock-solaris",
-      "version": "1.0.170",
+      "version": "1.0.171",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontist/mock-solaris",
-  "version": "1.0.170",
+  "version": "1.0.171",
   "description": "Mock Service for Solaris API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,6 +32,7 @@ import * as termsAPI from "./routes/termsAndConditions";
 import * as psd2API from "./routes/psd2";
 import * as postboxItemAPI from "./routes/postbox";
 import * as topUpsAPI from "./routes/topUps";
+import * as verificationOfPayeeAPI from "./routes/verificationOfPayee";
 import * as instantCreditTransferAPI from "./routes/instantCreditTransfer";
 import * as accountOpeningRequestAPI from "./routes/accountOpeningRequest";
 import * as accountClosureRequestAPI from "./routes/accountClosureRequest";
@@ -432,6 +433,12 @@ router.get(
 router.patch(
   "/persons/:person_id/tax_identifications/:id",
   safeRequestHandler(taxIdentificationsAPI.updateTaxIdentification)
+);
+
+// VERIFICATION OF PAYEE
+router.post(
+  "/verifications_of_payee",
+  safeRequestHandler(verificationOfPayeeAPI.verifyPayee)
 );
 
 // TRANSACTIONS

--- a/src/helpers/verificationOfPayee.ts
+++ b/src/helpers/verificationOfPayee.ts
@@ -1,4 +1,6 @@
-const vopStartDate = new Date("2025-10-09");
+// Date is set to 6th October for internal testing
+// The real final start date is 9th October 2025
+const vopStartDate = new Date("2025-10-06");
 
 export const isVerificationOfPayeeRequired = (): boolean => {
   const currentDate = new Date();

--- a/src/helpers/verificationOfPayee.ts
+++ b/src/helpers/verificationOfPayee.ts
@@ -1,0 +1,7 @@
+const vopStartDate = new Date("2025-10-09");
+
+export const isVerificationOfPayeeEnabled = (): boolean => {
+  const currentDate = new Date();
+
+  return currentDate >= vopStartDate;
+};

--- a/src/helpers/verificationOfPayee.ts
+++ b/src/helpers/verificationOfPayee.ts
@@ -1,6 +1,6 @@
 const vopStartDate = new Date("2025-10-09");
 
-export const isVerificationOfPayeeEnabled = (): boolean => {
+export const isVerificationOfPayeeRequired = (): boolean => {
   const currentDate = new Date();
 
   return currentDate >= vopStartDate;

--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -19,7 +19,7 @@ import {
 import { createSepaDirectDebitReturn } from "../helpers/sepaDirectDebitReturn";
 import { triggerBookingsWebhook } from "./backoffice";
 import generateID from "../helpers/id";
-import { isVerificationOfPayeeEnabled } from "../helpers/verificationOfPayee";
+import { isVerificationOfPayeeRequired } from "../helpers/verificationOfPayee";
 
 export const DIRECT_DEBIT_REFUND_METHOD = "direct_debit_refund";
 
@@ -147,7 +147,7 @@ export const createSepaCreditTransfer = async (req, res) => {
   const { person_id: personId, account_id: accountId } = req.params;
   const transfer = req.body;
 
-  if (isVerificationOfPayeeEnabled() && !transfer.verification_of_payee_id) {
+  if (isVerificationOfPayeeRequired() && !transfer.verification_of_payee_id) {
     return res.status(400).send({
       errors: [
         {

--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -19,6 +19,7 @@ import {
 import { createSepaDirectDebitReturn } from "../helpers/sepaDirectDebitReturn";
 import { triggerBookingsWebhook } from "./backoffice";
 import generateID from "../helpers/id";
+import { isVerificationOfPayeeEnabled } from "../helpers/verificationOfPayee";
 
 export const DIRECT_DEBIT_REFUND_METHOD = "direct_debit_refund";
 
@@ -145,6 +146,20 @@ export const SEPA_TRANSFER_METHOD = "SEPA_TRANSFER_METHOD";
 export const createSepaCreditTransfer = async (req, res) => {
   const { person_id: personId, account_id: accountId } = req.params;
   const transfer = req.body;
+
+  if (isVerificationOfPayeeEnabled() && !transfer.verification_of_payee_id) {
+    return res.status(400).send({
+      errors: [
+        {
+          id: generateID(),
+          status: 400,
+          code: "bad_request",
+          title: "Bad Request",
+          detail: `Verification of payee is required.`,
+        },
+      ],
+    });
+  }
 
   log.debug("createSepaCreditTransfer", {
     body: req.body,

--- a/src/routes/verificationOfPayee.ts
+++ b/src/routes/verificationOfPayee.ts
@@ -1,0 +1,76 @@
+import _ from "lodash";
+import type { Request, Response } from "express";
+import uuid from "node-uuid";
+import HttpStatusCodes from "http-status";
+
+export const verifyPayee = (req: Request, res: Response) => {
+  const data = _.pick(req.body, ["iban", "name"]);
+  const { iban, name } = data;
+
+  if (!iban) {
+    return res.status(HttpStatusCodes.BAD_REQUEST).send({
+      errors: [
+        {
+          id: uuid.v4(),
+          status: HttpStatusCodes.BAD_REQUEST,
+          code: "bad_request",
+          title: "Bad Request",
+          detail: "IBAN is required.",
+        },
+      ],
+    });
+  }
+
+  if (!name) {
+    return res.status(HttpStatusCodes.BAD_REQUEST).send({
+      errors: [
+        {
+          id: uuid.v4(),
+          status: HttpStatusCodes.BAD_REQUEST,
+          code: "bad_request",
+          title: "Bad Request",
+          detail: "Name is required.",
+        },
+      ],
+    });
+  }
+
+  let result;
+
+  switch (name) {
+    case "NO_MATCH":
+      result = {
+        status: "NO_MATCH",
+      };
+      break;
+    case "VERIFICATION_NOT_POSSIBLE":
+      result = {
+        status: "VERIFICATION_NOT_POSSIBLE",
+      };
+      break;
+    case "CLOSE_MATCH":
+      result = {
+        status: "CLOSE_MATCH",
+        suggested_name: "John Doe",
+      };
+      break;
+    default:
+      result = {
+        status: "MATCH",
+      };
+  }
+
+  const dateNow = new Date();
+  const response = {
+    id: uuid.v4(),
+    payee: {
+      iban,
+      name,
+    },
+    result,
+    created_at: dateNow.toISOString(),
+    expires_at: new Date(dateNow.getTime() + 5 * 60 * 1000).toISOString(),
+  };
+
+  return res.status(HttpStatusCodes.CREATED).send(response);
+};

--- a/src/routes/verificationOfPayee.ts
+++ b/src/routes/verificationOfPayee.ts
@@ -3,6 +3,23 @@ import type { Request, Response } from "express";
 import uuid from "node-uuid";
 import HttpStatusCodes from "http-status";
 
+const nameValidation: RegExp = /^[\p{L}\p{M}\p{N}\p{P}\p{S}\s]+$/u;
+
+const noMatchRegex: RegExp = /no[_ ]match/i;
+const notPossibleRegex: RegExp = /not[_ ]possible/i;
+const closeMatchRegex: RegExp = /close[_ ]match/i;
+
+/**
+ * Creates a verification of Payee
+ *
+ * By default will always return a "MATCH" status.
+ * For other statuses use the appropriate regex patterns in the name field.
+ * - "NO_MATCH": if name contains "no match" or "no_match" - case insensitive
+ * - "VERIFICATION_NOT_POSSIBLE": if name contains "not possible" or "not_possible" - case insensitive
+ * - "CLOSE_MATCH": if name contains "close match" or "close_match" - case insensitive
+ *
+ * @see https://docs.solarisgroup.com/api-reference/digital-banking/sepa-transfers/#tag/Verification-of-Payee/paths/~1v1~1verifications_of_payee/post
+ */
 export const verifyPayee = (req: Request, res: Response) => {
   const data = _.pick(req.body, ["iban", "name"]);
   const { iban, name } = data;
@@ -35,29 +52,39 @@ export const verifyPayee = (req: Request, res: Response) => {
     });
   }
 
-  let result;
+  if (!nameValidation.test(name) || name.length > 140) {
+    return res.status(HttpStatusCodes.BAD_REQUEST).send({
+      errors: [
+        {
+          id: uuid.v4(),
+          status: HttpStatusCodes.BAD_REQUEST,
+          code: "bad_request",
+          title: "Bad Request",
+          detail: "Name is not valid.",
+        },
+      ],
+    });
+  }
 
-  switch (name) {
-    case "NO_MATCH":
-      result = {
-        status: "NO_MATCH",
-      };
-      break;
-    case "VERIFICATION_NOT_POSSIBLE":
-      result = {
-        status: "VERIFICATION_NOT_POSSIBLE",
-      };
-      break;
-    case "CLOSE_MATCH":
-      result = {
-        status: "CLOSE_MATCH",
-        suggested_name: "John Doe",
-      };
-      break;
-    default:
-      result = {
-        status: "MATCH",
-      };
+  let result: { status: string; suggested_name?: string } = { status: "MATCH" };
+
+  if (noMatchRegex.test(name)) {
+    result = {
+      status: "NO_MATCH",
+    };
+  }
+
+  if (notPossibleRegex.test(name)) {
+    result = {
+      status: "VERIFICATION_NOT_POSSIBLE",
+    };
+  }
+
+  if (closeMatchRegex.test(name)) {
+    result = {
+      status: "CLOSE_MATCH",
+      suggested_name: "Giovanni Kontistini",
+    };
   }
 
   const dateNow = new Date();

--- a/tests/helpers/verificationOfPayee.spec.ts
+++ b/tests/helpers/verificationOfPayee.spec.ts
@@ -1,0 +1,26 @@
+import sinon from "sinon";
+import { expect } from "chai";
+
+import { isVerificationOfPayeeEnabled } from "../../src/helpers/verificationOfPayee";
+
+describe("isVerificationOfPayeeEnabled", () => {
+  let clock;
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it("should return true if verification of payee is enabled", () => {
+    // 1st November 2025
+    clock = sinon.useFakeTimers(new Date(2025, 10, 1).getTime());
+
+    expect(isVerificationOfPayeeEnabled()).to.be.true;
+  });
+
+  it("should return false if verification of payee is not enabled", () => {
+    // 1st October 2025
+    clock = sinon.useFakeTimers(new Date(2025, 9, 1).getTime());
+
+    expect(isVerificationOfPayeeEnabled()).to.be.false;
+  });
+});

--- a/tests/helpers/verificationOfPayee.spec.ts
+++ b/tests/helpers/verificationOfPayee.spec.ts
@@ -1,9 +1,9 @@
 import sinon from "sinon";
 import { expect } from "chai";
 
-import { isVerificationOfPayeeEnabled } from "../../src/helpers/verificationOfPayee";
+import { isVerificationOfPayeeRequired } from "../../src/helpers/verificationOfPayee";
 
-describe("isVerificationOfPayeeEnabled", () => {
+describe("isVerificationOfPayeeRequired", () => {
   let clock;
 
   afterEach(() => {
@@ -14,13 +14,13 @@ describe("isVerificationOfPayeeEnabled", () => {
     // 1st November 2025
     clock = sinon.useFakeTimers(new Date(2025, 10, 1).getTime());
 
-    expect(isVerificationOfPayeeEnabled()).to.be.true;
+    expect(isVerificationOfPayeeRequired()).to.be.true;
   });
 
   it("should return false if verification of payee is not enabled", () => {
     // 1st October 2025
     clock = sinon.useFakeTimers(new Date(2025, 9, 1).getTime());
 
-    expect(isVerificationOfPayeeEnabled()).to.be.false;
+    expect(isVerificationOfPayeeRequired()).to.be.false;
   });
 });

--- a/tests/routes/transactions.spec.ts
+++ b/tests/routes/transactions.spec.ts
@@ -1,26 +1,27 @@
 import sinon from "sinon";
 import { expect } from "chai";
+import { mockReq, mockRes } from "sinon-express-mock";
 
 import * as db from "../../src/db";
 import * as transactions from "../../src/routes/transactions";
 import { createPerson } from "../../src/routes/persons";
 
 describe("Transactions", () => {
-  let res;
-  const createPersonReq = {
-    body: {},
-    headers: {},
-  };
-
-  beforeEach(async () => {
-    await db.flushDb();
-    res = {
-      status: sinon.stub().callsFake(() => res),
-      send: sinon.stub(),
-    };
-  });
-
   describe("directDebitRefund", () => {
+    let res;
+    const createPersonReq = {
+      body: {},
+      headers: {},
+    };
+
+    beforeEach(async () => {
+      await db.flushDb();
+      res = {
+        status: sinon.stub().callsFake(() => res),
+        send: sinon.stub(),
+      };
+    });
+
     const req = (personId) => ({
       params: {
         person_id: personId,
@@ -51,6 +52,36 @@ describe("Transactions", () => {
           transactions.DIRECT_DEBIT_REFUND_METHOD
         );
       });
+    });
+  });
+
+  describe("createSepaCreditTransfer", () => {
+    let clock;
+
+    after(() => {
+      clock.restore();
+    });
+
+    it("should throw error if verification of payee is required and not passed", async () => {
+      // 1st November 2025
+      clock = sinon.useFakeTimers(new Date(2025, 10, 1).getTime());
+
+      const req = mockReq({
+        params: {
+          person_id: "person-id",
+          account_id: "account-id",
+        },
+        body: {},
+      });
+      const res = mockRes();
+
+      await transactions.createSepaCreditTransfer(req, res);
+
+      expect(res.status.calledWith(400)).to.be.true;
+      expect(res.send.calledOnce).to.be.true;
+      expect(res.send.args[0][0].errors[0].detail).to.deep.equal(
+        "Verification of payee is required."
+      );
     });
   });
 });

--- a/tests/routes/verificationOfPayee.spec.ts
+++ b/tests/routes/verificationOfPayee.spec.ts
@@ -65,11 +65,11 @@ describe("VerificationOfPayee", () => {
 
         expect(res.status.calledWith(200)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0][0].payee.iban).to.deep.equal(
+        expect(res.send.args[0].payee.iban).to.deep.equal(
           "DE89370400440532013000"
         );
-        expect(res.send.args[0][0].payee.name).to.deep.equal("John Doe");
-        expect(res.send.args[0][0].result.status).to.deep.equal("MATCH");
+        expect(res.send.args[0].payee.name).to.deep.equal("John Doe");
+        expect(res.send.args[0].result.status).to.deep.equal("MATCH");
       });
 
       it("should return NO_MATCH for a specific name", async () => {
@@ -85,11 +85,11 @@ describe("VerificationOfPayee", () => {
 
         expect(res.status.calledWith(200)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0][0].payee.iban).to.deep.equal(
+        expect(res.send.args[0].payee.iban).to.deep.equal(
           "DE89370400440532013000"
         );
-        expect(res.send.args[0][0].payee.name).to.deep.equal("John no match");
-        expect(res.send.args[0][0].result.status).to.deep.equal("NO_MATCH");
+        expect(res.send.args[0].payee.name).to.deep.equal("John no match");
+        expect(res.send.args[0].result.status).to.deep.equal("NO_MATCH");
       });
 
       it("should return VERIFICATION_NOT_POSSIBLE for a specific name", async () => {
@@ -105,13 +105,11 @@ describe("VerificationOfPayee", () => {
 
         expect(res.status.calledWith(200)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0][0].payee.iban).to.deep.equal(
+        expect(res.send.args[0].payee.iban).to.deep.equal(
           "DE89370400440532013000"
         );
-        expect(res.send.args[0][0].payee.name).to.deep.equal(
-          "John not possible"
-        );
-        expect(res.send.args[0][0].result.status).to.deep.equal(
+        expect(res.send.args[0].payee.name).to.deep.equal("John not possible");
+        expect(res.send.args[0].result.status).to.deep.equal(
           "VERIFICATION_NOT_POSSIBLE"
         );
       });
@@ -129,14 +127,12 @@ describe("VerificationOfPayee", () => {
 
         expect(res.status.calledWith(200)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0][0].payee.iban).to.deep.equal(
+        expect(res.send.args[0].payee.iban).to.deep.equal(
           "DE89370400440532013000"
         );
-        expect(res.send.args[0][0].payee.name).to.deep.equal(
-          "John close match"
-        );
-        expect(res.send.args[0][0].result.status).to.deep.equal("CLOSE_MATCH");
-        expect(res.send.args[0][0].result.suggested_name).to.deep.equal(
+        expect(res.send.args[0].payee.name).to.deep.equal("John close match");
+        expect(res.send.args[0].result.status).to.deep.equal("CLOSE_MATCH");
+        expect(res.send.args[0].result.suggested_name).to.deep.equal(
           "Giovanni Kontistini"
         );
       });

--- a/tests/routes/verificationOfPayee.spec.ts
+++ b/tests/routes/verificationOfPayee.spec.ts
@@ -19,6 +19,9 @@ describe("VerificationOfPayee", () => {
 
         expect(res.status.calledWith(400)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
+        expect(res.send.args[0].errors[0].detail).to.deep.equal(
+          "IBAN is required."
+        );
       });
 
       it("should return a 400 error if name is missing", async () => {
@@ -33,6 +36,9 @@ describe("VerificationOfPayee", () => {
 
         expect(res.status.calledWith(400)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
+        expect(res.send.args[0].errors[0].detail).to.deep.equal(
+          "Name is required."
+        );
       });
 
       it("should return a 400 error if name is invalid", async () => {
@@ -48,6 +54,9 @@ describe("VerificationOfPayee", () => {
 
         expect(res.status.calledWith(400)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
+        expect(res.send.args[0].errors[0].detail).to.deep.equal(
+          "Name is not valid."
+        );
       });
     });
 

--- a/tests/routes/verificationOfPayee.spec.ts
+++ b/tests/routes/verificationOfPayee.spec.ts
@@ -1,0 +1,145 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import { mockReq, mockRes } from "sinon-express-mock";
+
+import { verifyPayee } from "../../src/routes/verificationOfPayee";
+
+describe("VerificationOfPayee", () => {
+  describe("verifyPayee", () => {
+    describe("should throw validation errors", () => {
+      it("should return a 400 error if IBAN is missing", async () => {
+        const req = mockReq({
+          body: {
+            name: "John Doe",
+          },
+        });
+        const res = mockRes();
+
+        await verifyPayee(req, res);
+
+        expect(res.status.calledWith(400)).to.be.true;
+        expect(res.send.calledOnce).to.be.true;
+      });
+
+      it("should return a 400 error if name is missing", async () => {
+        const req = mockReq({
+          body: {
+            iban: "DE89370400440532013000",
+          },
+        });
+        const res = mockRes();
+
+        await verifyPayee(req, res);
+
+        expect(res.status.calledWith(400)).to.be.true;
+        expect(res.send.calledOnce).to.be.true;
+      });
+
+      it("should return a 400 error if name is invalid", async () => {
+        const req = mockReq({
+          body: {
+            iban: "DE89370400440532013000",
+            name: "Tooooooooo looooooooooooooong of a naaaaaaaaaaaaaaame Tooooooooo looooooooooooooong of a naaaaaaaaaaaaaaame Tooooooooo looooooooooooooong of a naaaaaaaaaaaaaaame",
+          },
+        });
+        const res = mockRes();
+
+        await verifyPayee(req, res);
+
+        expect(res.status.calledWith(400)).to.be.true;
+        expect(res.send.calledOnce).to.be.true;
+      });
+    });
+
+    describe("should return the correct payload with appropriate status", () => {
+      it("should return MATCH for any default name", async () => {
+        const req = mockReq({
+          body: {
+            iban: "DE89370400440532013000",
+            name: "John Doe",
+          },
+        });
+        const res = mockRes();
+
+        await verifyPayee(req, res);
+
+        expect(res.status.calledWith(200)).to.be.true;
+        expect(res.send.calledOnce).to.be.true;
+        expect(res.send.args[0][0].payee.iban).to.deep.equal(
+          "DE89370400440532013000"
+        );
+        expect(res.send.args[0][0].payee.name).to.deep.equal("John Doe");
+        expect(res.send.args[0][0].result.status).to.deep.equal("MATCH");
+      });
+
+      it("should return NO_MATCH for a specific name", async () => {
+        const req = mockReq({
+          body: {
+            iban: "DE89370400440532013000",
+            name: "John no match",
+          },
+        });
+        const res = mockRes();
+
+        await verifyPayee(req, res);
+
+        expect(res.status.calledWith(200)).to.be.true;
+        expect(res.send.calledOnce).to.be.true;
+        expect(res.send.args[0][0].payee.iban).to.deep.equal(
+          "DE89370400440532013000"
+        );
+        expect(res.send.args[0][0].payee.name).to.deep.equal("John no match");
+        expect(res.send.args[0][0].result.status).to.deep.equal("NO_MATCH");
+      });
+
+      it("should return VERIFICATION_NOT_POSSIBLE for a specific name", async () => {
+        const req = mockReq({
+          body: {
+            iban: "DE89370400440532013000",
+            name: "John not possible",
+          },
+        });
+        const res = mockRes();
+
+        await verifyPayee(req, res);
+
+        expect(res.status.calledWith(200)).to.be.true;
+        expect(res.send.calledOnce).to.be.true;
+        expect(res.send.args[0][0].payee.iban).to.deep.equal(
+          "DE89370400440532013000"
+        );
+        expect(res.send.args[0][0].payee.name).to.deep.equal(
+          "John not possible"
+        );
+        expect(res.send.args[0][0].result.status).to.deep.equal(
+          "VERIFICATION_NOT_POSSIBLE"
+        );
+      });
+
+      it("should return CLOSE_MATCH for a specific name", async () => {
+        const req = mockReq({
+          body: {
+            iban: "DE89370400440532013000",
+            name: "John close match",
+          },
+        });
+        const res = mockRes();
+
+        await verifyPayee(req, res);
+
+        expect(res.status.calledWith(200)).to.be.true;
+        expect(res.send.calledOnce).to.be.true;
+        expect(res.send.args[0][0].payee.iban).to.deep.equal(
+          "DE89370400440532013000"
+        );
+        expect(res.send.args[0][0].payee.name).to.deep.equal(
+          "John close match"
+        );
+        expect(res.send.args[0][0].result.status).to.deep.equal("CLOSE_MATCH");
+        expect(res.send.args[0][0].result.suggested_name).to.deep.equal(
+          "Giovanni Kontistini"
+        );
+      });
+    });
+  });
+});

--- a/tests/routes/verificationOfPayee.spec.ts
+++ b/tests/routes/verificationOfPayee.spec.ts
@@ -19,7 +19,7 @@ describe("VerificationOfPayee", () => {
 
         expect(res.status.calledWith(400)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0].errors[0].detail).to.deep.equal(
+        expect(res.send.args[0][0].errors[0].detail).to.deep.equal(
           "IBAN is required."
         );
       });
@@ -36,7 +36,7 @@ describe("VerificationOfPayee", () => {
 
         expect(res.status.calledWith(400)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0].errors[0].detail).to.deep.equal(
+        expect(res.send.args[0][0].errors[0].detail).to.deep.equal(
           "Name is required."
         );
       });
@@ -54,7 +54,7 @@ describe("VerificationOfPayee", () => {
 
         expect(res.status.calledWith(400)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0].errors[0].detail).to.deep.equal(
+        expect(res.send.args[0][0].errors[0].detail).to.deep.equal(
           "Name is not valid."
         );
       });
@@ -72,13 +72,13 @@ describe("VerificationOfPayee", () => {
 
         await verifyPayee(req, res);
 
-        expect(res.status.calledWith(200)).to.be.true;
+        expect(res.status.calledWith(201)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0].payee.iban).to.deep.equal(
+        expect(res.send.args[0][0].payee.iban).to.deep.equal(
           "DE89370400440532013000"
         );
-        expect(res.send.args[0].payee.name).to.deep.equal("John Doe");
-        expect(res.send.args[0].result.status).to.deep.equal("MATCH");
+        expect(res.send.args[0][0].payee.name).to.deep.equal("John Doe");
+        expect(res.send.args[0][0].result.status).to.deep.equal("MATCH");
       });
 
       it("should return NO_MATCH for a specific name", async () => {
@@ -92,13 +92,13 @@ describe("VerificationOfPayee", () => {
 
         await verifyPayee(req, res);
 
-        expect(res.status.calledWith(200)).to.be.true;
+        expect(res.status.calledWith(201)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0].payee.iban).to.deep.equal(
+        expect(res.send.args[0][0].payee.iban).to.deep.equal(
           "DE89370400440532013000"
         );
-        expect(res.send.args[0].payee.name).to.deep.equal("John no match");
-        expect(res.send.args[0].result.status).to.deep.equal("NO_MATCH");
+        expect(res.send.args[0][0].payee.name).to.deep.equal("John no match");
+        expect(res.send.args[0][0].result.status).to.deep.equal("NO_MATCH");
       });
 
       it("should return VERIFICATION_NOT_POSSIBLE for a specific name", async () => {
@@ -112,13 +112,15 @@ describe("VerificationOfPayee", () => {
 
         await verifyPayee(req, res);
 
-        expect(res.status.calledWith(200)).to.be.true;
+        expect(res.status.calledWith(201)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0].payee.iban).to.deep.equal(
+        expect(res.send.args[0][0].payee.iban).to.deep.equal(
           "DE89370400440532013000"
         );
-        expect(res.send.args[0].payee.name).to.deep.equal("John not possible");
-        expect(res.send.args[0].result.status).to.deep.equal(
+        expect(res.send.args[0][0].payee.name).to.deep.equal(
+          "John not possible"
+        );
+        expect(res.send.args[0][0].result.status).to.deep.equal(
           "VERIFICATION_NOT_POSSIBLE"
         );
       });
@@ -134,14 +136,16 @@ describe("VerificationOfPayee", () => {
 
         await verifyPayee(req, res);
 
-        expect(res.status.calledWith(200)).to.be.true;
+        expect(res.status.calledWith(201)).to.be.true;
         expect(res.send.calledOnce).to.be.true;
-        expect(res.send.args[0].payee.iban).to.deep.equal(
+        expect(res.send.args[0][0].payee.iban).to.deep.equal(
           "DE89370400440532013000"
         );
-        expect(res.send.args[0].payee.name).to.deep.equal("John close match");
-        expect(res.send.args[0].result.status).to.deep.equal("CLOSE_MATCH");
-        expect(res.send.args[0].result.suggested_name).to.deep.equal(
+        expect(res.send.args[0][0].payee.name).to.deep.equal(
+          "John close match"
+        );
+        expect(res.send.args[0][0].result.status).to.deep.equal("CLOSE_MATCH");
+        expect(res.send.args[0][0].result.suggested_name).to.deep.equal(
           "Giovanni Kontistini"
         );
       });


### PR DESCRIPTION
New endpoint is added following the [requirements of Solaris](https://docs.solarisgroup.com/api-reference/digital-banking/sepa-transfers/#tag/Verification-of-Payee/paths/~1v1~1verifications_of_payee/post):
- By default will always return a "MATCH" status.

For other statuses use the appropriate regex patterns in the name field.
- "NO_MATCH": if name contains "no match" or "no_match" - case insensitive
- "VERIFICATION_NOT_POSSIBLE": if name contains "not possible" or "not_possible" - case insensitive
- "CLOSE_MATCH": if name contains "close match" or "close_match" - case insensitive

Also made the `verification_of_payee` a required field from 9th Oct 2025 on the `createSepaCreditTransfer` endpoint.
We currently do not have the Sepa Instant Transfer implemented, so couldn't be added there.
Also for now, I left the batch transfers out, as this requires more planning. (also can be opted out of)